### PR TITLE
[IIIF-1194] Add Cantaloupe to build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,44 @@ A IIIF Auth implementation for limiting access by IP address.
 
 Still in development.
 
+## Prerequisites
+
+To build Hauth, you need the following things installed and configured on your local machine:
+
+* [Java](https://adoptopenjdk.net/) &gt;= JDK 11
+* [Maven](https://maven.apache.org/download.cgi) &gt;= 3.8.x
+* [Docker](https://www.docker.com/products/container-runtime) &gt;= 20.10.x
+
+## Building
+
+To build the project, run:
+
+    mvn verify
+
+This will run the build and all the unit and integration tests.
+
+## Running in Developer Mode
+
+To bring up the server locally for testing or development purposes, run:
+
+    mvn -Plive integration-test
+
+This will spin up Hauth locally, along with the Redis, PostgreSQL, and Cantaloupe Docker containers. You can also, optionally, supply `-Ddocker.showLogs` if you want to see the containers' logs.
+
 ## Environmental Properties
+
+These are a work in progress. None of these need to be supplied when running in developer mode. Randomized ports and passwords are created on the fly. The port numbers can be seen in the Maven output.
 
 | ENV Property | Default Value | Required |
 --- | --- | ---
 | HTTP_PORT | 8888 | No |
 | HTTP_HOST | 0.0.0.0 | No |
 | API_SPEC | hauth.yaml | No |
-
+| DB_HOST | XXX | Yes |
+| DB_PORT | 5432 | No |
+| DB_PASSWORD | XXX | Yes |
+| DB_CACHE_HOST | XXX | Yes |
+| DB_CACHE_PORT | 6379 | No |
+| IIIF_SERVER_HOST | XXX | Yes |
+| IIIF_SERVER_PORT | 8182 | No |
+--- | --- | ---

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,9 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>${docker.maven.plugin.version}</version>
@@ -310,7 +313,7 @@
                   <CANTALOUPE_ENDPOINT_ADMIN_SECRET>secret</CANTALOUPE_ENDPOINT_ADMIN_SECRET>
                   <CANTALOUPE_ENDPOINT_ADMIN_ENABLED>true</CANTALOUPE_ENDPOINT_ADMIN_ENABLED>
                   <CANTALOUPE_DELEGATE_SCRIPT_ENABLED>true</CANTALOUPE_DELEGATE_SCRIPT_ENABLED>
-<!--                   <CANTALOUPE_DELEGATE_SCRIPT_PATHNAME>delegate.jar</CANTALOUPE_DELEGATE_SCRIPT_PATHNAME> -->
+                  <CANTALOUPE_DELEGATE_SCRIPT_PATHNAME>delegate.jar</CANTALOUPE_DELEGATE_SCRIPT_PATHNAME>
                   <DELEGATE_URL>${snapshot.url}</DELEGATE_URL>
                 </env>
                 <wait>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <!-- Build plugin versions -->
     <jar.plugin.version>3.2.0</jar.plugin.version>
     <vertx.plugin.version>1.0.24</vertx.plugin.version>
-    <freelib.maven.version>0.2.0</freelib.maven.version>
+    <freelib.maven.version>0.3.0</freelib.maven.version>
     <deploy.plugin.version>3.0.0-M1</deploy.plugin.version>
     <docker.maven.plugin.version>0.36.0</docker.maven.plugin.version>
 
@@ -186,6 +186,7 @@
             <portName>test.http.port</portName>
             <portName>test.db.port</portName>
             <portName>test.db.cache.port</portName>
+            <portName>test.iiif.images.port</portName>
           </portNames>
         </configuration>
         <executions>
@@ -222,6 +223,17 @@
               <name>test.db.password</name>
             </configuration>
           </execution>
+          <execution>
+            <id>set-snapshot-url</id>
+            <goals>
+              <goal>set-snapshot-url</goal>
+            </goals>
+            <configuration>
+              <snapshot.artifact>cantaloupe-auth-delegate</snapshot.artifact>
+              <snapshot.group>edu.ucla.library</snapshot.group>
+              <snapshot.version>0.0.1-SNAPSHOT</snapshot.version>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -243,9 +255,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>io.fabric8</groupId>
@@ -285,6 +294,30 @@
                 </wait>
               </run>
             </hauth_redis>
+            <hauth_cantaloupe>
+              <name>uclalibrary/cantaloupe:5.0.3-0</name>
+              <run>
+                <containerNamePattern>hauth_cantaloupe</containerNamePattern>
+                <ports>
+                  <port>${test.iiif.images.port}:8182</port>
+                </ports>
+                <volumes>
+                  <bind>
+                    <volume>${project.basedir}/src/test/resources/images/:/imageroot/</volume>
+                  </bind>
+                </volumes>
+                <env>
+                  <CANTALOUPE_ENDPOINT_ADMIN_SECRET>secret</CANTALOUPE_ENDPOINT_ADMIN_SECRET>
+                  <CANTALOUPE_ENDPOINT_ADMIN_ENABLED>true</CANTALOUPE_ENDPOINT_ADMIN_ENABLED>
+                  <CANTALOUPE_DELEGATE_SCRIPT_ENABLED>true</CANTALOUPE_DELEGATE_SCRIPT_ENABLED>
+<!--                   <CANTALOUPE_DELEGATE_SCRIPT_PATHNAME>delegate.jar</CANTALOUPE_DELEGATE_SCRIPT_PATHNAME> -->
+                  <DELEGATE_URL>${snapshot.url}</DELEGATE_URL>
+                </env>
+                <wait>
+                  <log>Started @</log>
+                </wait>
+              </run>
+            </hauth_cantaloupe>
             <hauth>
               <!-- Registry account, if supplied, must end in a slash (e.g. "account/") -->
               <!-- The %l at the end translates to "latest" if version ends in "-SNAPSHOT" -->
@@ -336,6 +369,7 @@
                     <status>200</status>
                   </http>
                 </wait>
+                <skip>${skip.hauth.container}</skip>
               </run>
             </hauth>
           </imagesMap>
@@ -536,6 +570,7 @@
       <properties>
         <maven.test.skip>true</maven.test.skip>
         <jacoco.skip>true</jacoco.skip>
+        <skip.hauth.container>true</skip.hauth.container>
       </properties>
       <build>
         <plugins>
@@ -551,13 +586,6 @@
                 <configuration>
                   <outputDirectory>${basedir}/target/classes/</outputDirectory>
                   <resources>
-                    <resource>
-                      <directory>${basedir}/src/main/resources</directory>
-                      <filtering>true</filtering>
-                      <includes>
-                        <include>fester.yaml</include>
-                      </includes>
-                    </resource>
                     <resource>
                       <directory>${basedir}</directory>
                       <filtering>true</filtering>
@@ -578,7 +606,7 @@
             <executions>
               <execution>
                 <id>test-vertx-startup</id>
-                <phase>test</phase>
+                <phase>integration-test</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>


### PR DESCRIPTION
* Flesh out the README a bit more (projecting into the future a bit with some of the config variables)
* Add `set-snapshot-url` Maven plugin so we can reference the snapshot version of cantaloupe-auth-delegate
* Add Cantaloupe container to the build
* Reconfigure to run the `live` application tests at the `integration-test` phase (to be able to use containers)