### PR TITLE
[IIIF-1216] Update parent project, set version to CI-friendly form

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,9 @@
     <!-- Application dependencies -->
     <freelib.utils.version>2.4.0</freelib.utils.version>
     <slf4j.ext.version>1.7.30</slf4j.ext.version>
+    <cidr.ip.version>1.0.1</cidr.ip.version>
     <vertx.version>4.1.4</vertx.version>
+
 
     <!-- Security fixes for transitive dependencies -->
     <jetty.version>4.1.68.Final</jetty.version>
@@ -60,6 +62,10 @@
     <!-- Test dependency versions -->
     <mockito.version>3.11.1</mockito.version>
     <junit.version>5.8.0-M1</junit.version>
+    <redis.version>6.2.5-alpine</redis.version>
+    <postgres.version>12.7-alpine</postgres.version>
+    <cantaloupe.version>5.0.3-0</cantaloupe.version>
+    <auth.delegate.version>0.0.1-SNAPSHOT</auth.delegate.version>
 
     <!-- Name of the main Vert.x verticle -->
     <main.verticle>edu.ucla.library.iiif.auth.verticles.MainVerticle</main.verticle>
@@ -147,7 +153,7 @@
     <dependency>
       <groupId>com.github.veqryn</groupId>
       <artifactId>cidr-ip-trie</artifactId>
-      <version>1.0.1</version>
+      <version>${cidr.ip.version}</version>
     </dependency>
 
     <!-- Security fixes for transitive dependencies -->
@@ -277,7 +283,7 @@
             <configuration>
               <snapshot.artifact>cantaloupe-auth-delegate</snapshot.artifact>
               <snapshot.group>edu.ucla.library</snapshot.group>
-              <snapshot.version>0.0.1-SNAPSHOT</snapshot.version>
+              <snapshot.version>${auth.delegate.version}</snapshot.version>
             </configuration>
           </execution>
         </executions>
@@ -323,7 +329,7 @@
         <configuration>
           <imagesMap>
             <hauth_pgsql>
-              <name>postgres:12.7-alpine</name>
+              <name>postgres:${postgres.version}</name>
               <run>
                 <containerNamePattern>hauth_pgsql</containerNamePattern>
                 <ports>
@@ -343,7 +349,7 @@
               </run>
             </hauth_pgsql>
             <hauth_redis>
-              <name>redis:6.2.5-alpine</name>
+              <name>redis:${redis.version}</name>
               <run>
                 <containerNamePattern>hauth_redis</containerNamePattern>
                 <ports>
@@ -355,7 +361,7 @@
               </run>
             </hauth_redis>
             <hauth_cantaloupe>
-              <name>uclalibrary/cantaloupe:5.0.3-0</name>
+              <name>uclalibrary/cantaloupe:${cantaloupe.version}</name>
               <run>
                 <containerNamePattern>hauth_cantaloupe</containerNamePattern>
                 <ports>

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,10 @@
 
   <properties>
     <!-- Code build properties -->
-    <vertx.version>4.1.0</vertx.version>
-    <graalvm.version>21.0.0</graalvm.version>
+    <graalvm.version>21.2.0</graalvm.version>
 
     <!-- Docker build properties -->
-    <alpine.version>3.13.1</alpine.version>
+    <alpine.version>3.14.2</alpine.version>
     <builder.version>0.0.3</builder.version>
 
     <!-- Whether UPX should be used to compress the application -->
@@ -46,6 +45,10 @@
     <!-- Application dependencies -->
     <freelib.utils.version>2.4.0</freelib.utils.version>
     <slf4j.ext.version>1.7.30</slf4j.ext.version>
+    <vertx.version>4.1.4</vertx.version>
+
+    <!-- Security fixes for transitive dependencies -->
+    <jetty.version>4.1.68.Final</jetty.version>
 
     <!-- Build plugin versions -->
     <jar.plugin.version>3.2.0</jar.plugin.version>
@@ -145,6 +148,13 @@
       <groupId>com.github.veqryn</groupId>
       <artifactId>cidr-ip-trie</artifactId>
       <version>1.0.1</version>
+    </dependency>
+
+    <!-- Security fixes for transitive dependencies -->
+    <dependency> <!-- Used by Vert.x -->
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec</artifactId>
+      <version>${jetty.version}</version>
     </dependency>
 
     <!-- Below is a dependency that needs updating due to security issue (may be able to remove in future) -->
@@ -276,7 +286,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <!-- Incremental compilation causes problems with vertx-codegen; see example config at:
-               https://github.com/vert-x3/vertx-codegen/blob/0974676c45c95a4410d0d1620ada4f64514688ee/README.md#processor-configuration -->
+          https://github.com/vert-x3/vertx-codegen/blob/0974676c45c95a4410d0d1620ada4f64514688ee/README.md#processor-configuration -->
           <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
       </plugin>
@@ -302,6 +312,9 @@
       </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>io.fabric8</groupId>
@@ -409,7 +422,7 @@
                 <env>
                   <ACCESS_TOKEN_EXPIRES_IN>1800</ACCESS_TOKEN_EXPIRES_IN>
                   <HAUTH_VERSION>${project.version}</HAUTH_VERSION>
-                  <!--  Default Docker bridge host IP -->
+                  <!-- Default Docker bridge host IP -->
                   <DB_HOST>172.17.0.1</DB_HOST>
                   <DB_PORT>${test.db.port}</DB_PORT>
                   <DB_PASSWORD>${test.db.password}</DB_PASSWORD>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>edu.ucla.library</groupId>
   <artifactId>hauth</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>${revision}</version>
   <name>Hauth</name>
   <description>A IIIF authentication layer for IIIF image servers</description>
   <url>https://github.com/uclalibrary/hauth</url>
@@ -543,6 +543,10 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>net.revelc.code.formatter</groupId>
+        <artifactId>formatter-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 
@@ -700,10 +704,21 @@
     </profile>
   </profiles>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>6.9.2</version>
+    <version>7.0.1</version>
   </parent>
 
 </project>

--- a/src/main/java/edu/ucla/library/iiif/auth/CookieJsonKeys.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/CookieJsonKeys.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth;
 
 /**

--- a/src/main/java/edu/ucla/library/iiif/auth/ResponseJsonKeys.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/ResponseJsonKeys.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth;
 
 /**

--- a/src/main/java/edu/ucla/library/iiif/auth/TokenJsonKeys.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/TokenJsonKeys.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth;
 
 /**

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandler.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.handlers;
 
 import static info.freelibrary.util.Constants.COMMA;

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandler.java
@@ -39,8 +39,8 @@ public class AccessLevelHandler implements Handler<RoutingContext> {
 
         myDatabaseServiceProxy.getAccessLevel(id).onSuccess(accessLevel -> {
             final boolean isRestricted = accessLevel == 0 ? false : true;
-            final JsonObject data = new JsonObject().put(ResponseJsonKeys.ID, id).put(ResponseJsonKeys.RESTRICTED,
-                    isRestricted);
+            final JsonObject data =
+                    new JsonObject().put(ResponseJsonKeys.ID, id).put(ResponseJsonKeys.RESTRICTED, isRestricted);
 
             aContext.response().setStatusCode(HTTP.OK)
                     .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessTokenHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessTokenHandler.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.handlers;
 
 import java.util.Base64;
@@ -78,9 +79,9 @@ public class AccessTokenHandler implements Handler<RoutingContext> {
 
             // if the IP addresses match, send back the access token
             if (clientIpAddress.equals(cookieData.getString(CookieJsonKeys.CLIENT_IP_ADDRESS))) {
-                final JsonObject accessTokenUnencoded = new JsonObject()
-                        .put(TokenJsonKeys.VERSION, myConfig.getString(Config.HAUTH_VERSION))
-                        .put(TokenJsonKeys.CAMPUS_NETWORK, cookieData.getBoolean(CookieJsonKeys.CAMPUS_NETWORK));
+                final JsonObject accessTokenUnencoded =
+                        new JsonObject().put(TokenJsonKeys.VERSION, myConfig.getString(Config.HAUTH_VERSION)).put(
+                                TokenJsonKeys.CAMPUS_NETWORK, cookieData.getBoolean(CookieJsonKeys.CAMPUS_NETWORK));
                 final String accessToken = Base64.getEncoder().encodeToString(accessTokenUnencoded.encode().getBytes());
 
                 data.put(ResponseJsonKeys.ACCESS_TOKEN, accessToken).put(ResponseJsonKeys.EXPIRES_IN, myExpiresIn);
@@ -88,8 +89,8 @@ public class AccessTokenHandler implements Handler<RoutingContext> {
                 response.setStatusCode(HTTP.OK);
             } else {
                 final String responseMessage = LOGGER.getMessage(MessageCodes.AUTH_011);
-                data.put(ResponseJsonKeys.ERROR, AccessCookieServiceError.INVALID_COOKIE)
-                        .put(ResponseJsonKeys.MESSAGE, responseMessage);
+                data.put(ResponseJsonKeys.ERROR, AccessCookieServiceError.INVALID_COOKIE).put(ResponseJsonKeys.MESSAGE,
+                        responseMessage);
 
                 response.setStatusCode(HTTP.BAD_REQUEST);
 

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessTokenHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessTokenHandler.java
@@ -3,6 +3,10 @@ package edu.ucla.library.iiif.auth.handlers;
 
 import java.util.Base64;
 
+import info.freelibrary.util.HTTP;
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
 import edu.ucla.library.iiif.auth.Config;
 import edu.ucla.library.iiif.auth.CookieJsonKeys;
 import edu.ucla.library.iiif.auth.MessageCodes;
@@ -12,10 +16,6 @@ import edu.ucla.library.iiif.auth.services.AccessCookieService;
 import edu.ucla.library.iiif.auth.services.AccessCookieServiceError;
 import edu.ucla.library.iiif.auth.services.AccessCookieServiceImpl;
 import edu.ucla.library.iiif.auth.utils.MediaType;
-
-import info.freelibrary.util.HTTP;
-import info.freelibrary.util.Logger;
-import info.freelibrary.util.LoggerFactory;
 
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/DatabaseAccessFailureHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/DatabaseAccessFailureHandler.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.handlers;
 
 import edu.ucla.library.iiif.auth.MessageCodes;
@@ -26,8 +27,8 @@ public class DatabaseAccessFailureHandler implements Handler<RoutingContext> {
     /**
      * The handler's logger.
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseAccessFailureHandler.class,
-            MessageCodes.BUNDLE);
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(DatabaseAccessFailureHandler.class, MessageCodes.BUNDLE);
 
     @Override
     public void handle(final RoutingContext aContext) {

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/StatusHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/StatusHandler.java
@@ -1,11 +1,9 @@
 
 package edu.ucla.library.iiif.auth.handlers;
 
-import info.freelibrary.util.HTTP;
-
 import edu.ucla.library.iiif.auth.ResponseJsonKeys;
 import edu.ucla.library.iiif.auth.utils.MediaType;
-
+import info.freelibrary.util.HTTP;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
@@ -26,7 +24,7 @@ public class StatusHandler implements Handler<RoutingContext> {
     /**
      * Creates a handler that returns the status of the application.
      *
-     * @param aVertx
+     * @param aVertx A Vert.x instance
      */
     public StatusHandler(final Vertx aVertx) {
         myVertx = aVertx;

--- a/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieService.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieService.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.services;
 
 import java.security.GeneralSecurityException;
@@ -61,7 +62,7 @@ public interface AccessCookieService {
      * @param aIsOnCampusNetwork If the client is on a campus network subnet
      * @param aIsDegradedAllowed If the origin allows degraded access to content
      * @return A Future that resolves to a value that can be used to create a cookie with
-     * {@link Cookie#cookie(String, String)}
+     *         {@link Cookie#cookie(String, String)}
      */
     Future<String> generateCookie(String aClientIpAddress, boolean aIsOnCampusNetwork, boolean aIsDegradedAllowed);
 

--- a/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceError.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceError.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.services;
 
 /**

--- a/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceImpl.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.services;
 
 import java.security.InvalidAlgorithmParameterException;
@@ -41,8 +42,7 @@ public class AccessCookieServiceImpl implements AccessCookieService {
     /**
      * The access cookie service impl's logger.
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(AccessCookieServiceImpl.class,
-            MessageCodes.BUNDLE);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccessCookieServiceImpl.class, MessageCodes.BUNDLE);
 
     /**
      * The name of the algorithm to use for key derivation.
@@ -60,14 +60,12 @@ public class AccessCookieServiceImpl implements AccessCookieService {
     private static final String CIPHER_TRANSFORMATION = "AES/CBC/PKCS5Padding";
 
     /**
-     * The failure code to use for a ServiceException that represents
-     * {@link AccessCookieServiceError#CONFIGURATION}.
+     * The failure code to use for a ServiceException that represents {@link AccessCookieServiceError#CONFIGURATION}.
      */
     private static final int CONFIGURATION_ERROR = AccessCookieServiceError.CONFIGURATION.ordinal();
 
     /**
-     * The failure code to use for a ServiceException that represents
-     * {@link AccessCookieServiceError#INVALID_COOKIE}.
+     * The failure code to use for a ServiceException that represents {@link AccessCookieServiceError#INVALID_COOKIE}.
      */
     private static final int INVALID_COOKIE_ERROR = AccessCookieServiceError.INVALID_COOKIE.ordinal();
 
@@ -92,9 +90,7 @@ public class AccessCookieServiceImpl implements AccessCookieService {
     private final SecureRandom myInitializationVectorRng;
 
     /**
-     * Creates an instance of the service.
-     *
-     * For reference material on the key derivation crypto, see RFC 8018:
+     * Creates an instance of the service. For reference material on the key derivation crypto, see RFC 8018:
      * <ul>
      * <li><a href="https://datatracker.ietf.org/doc/html/rfc8018#section-4.1">Salt</a>
      * <li><a href="https://datatracker.ietf.org/doc/html/rfc8018#section-4.2">Iteration count</a>
@@ -104,7 +100,7 @@ public class AccessCookieServiceImpl implements AccessCookieService {
      * @param aConfig A configuration
      * @throws InvalidKeySpecException if the {@link KeySpec} was not instantiated correctly
      * @throws NoSuchAlgorithmException if either {@link KEY_DERIVATION_FUNCTION} or {@link CIPHER_TRANSFORMATION} are
-     * not valid algorithms
+     *         not valid algorithms
      * @throws NoSuchPaddingException if {@link CIPHER_TRANSFORMATION} contains a padding scheme that is not available
      */
     AccessCookieServiceImpl(final JsonObject aConfig)

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseService.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseService.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.services;
 
 import io.vertx.codegen.annotations.ProxyClose;

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceError.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceError.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.services;
 
 /**

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.services;
 
 import static info.freelibrary.util.Constants.SPACE;

--- a/src/main/java/edu/ucla/library/iiif/auth/services/package-info.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/package-info.java
@@ -1,6 +1,7 @@
 /**
  * Package info required for handling generated sources.
  */
+
 @ModuleGen(groupPackage = "edu.ucla.library.iiif.auth.services", name = "services", useFutures = true)
 package edu.ucla.library.iiif.auth.services;
 

--- a/src/main/java/edu/ucla/library/iiif/auth/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/verticles/MainVerticle.java
@@ -1,10 +1,10 @@
 
 package edu.ucla.library.iiif.auth.verticles;
 
+import java.security.GeneralSecurityException;
+
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
-
-import java.security.GeneralSecurityException;
 
 import edu.ucla.library.iiif.auth.Config;
 import edu.ucla.library.iiif.auth.MessageCodes;
@@ -88,9 +88,9 @@ public class MainVerticle extends AbstractVerticle {
 
     @Override
     public void stop(final Promise<Void> aPromise) {
-        final Future<Void> stopAll = CompositeFuture
-                .all(myDatabaseService.unregister(), myAccessCookieService.unregister())
-                .compose(result -> myServer.close());
+        final Future<Void> stopAll =
+                CompositeFuture.all(myDatabaseService.unregister(), myAccessCookieService.unregister())
+                        .compose(result -> myServer.close());
 
         stopAll.onSuccess(aPromise::complete).onFailure(aPromise::fail);
     }
@@ -116,8 +116,8 @@ public class MainVerticle extends AbstractVerticle {
             aPromise.fail(details.getMessage());
             return;
         }
-        myDatabaseService = serviceBinder.setAddress(DatabaseService.ADDRESS)
-                .register(DatabaseService.class, DatabaseService.create(getVertx(), aConfig));
+        myDatabaseService = serviceBinder.setAddress(DatabaseService.ADDRESS).register(DatabaseService.class,
+                DatabaseService.create(getVertx(), aConfig));
 
         RouterBuilder.create(vertx, apiSpec).onComplete(routerConfig -> {
             if (routerConfig.succeeded()) {

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AbstractHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AbstractHandlerIT.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.handlers;
 
 import java.security.GeneralSecurityException;

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandlerIT.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,8 +32,8 @@ public final class AccessCookieHandlerIT extends AbstractHandlerIT {
      */
     @Test
     public void testGetCookie(final Vertx aVertx, final VertxTestContext aContext) {
-        final String requestUri = StringUtils.format(GET_COOKIE_PATH,
-                URLEncoder.encode(TEST_ORIGIN, StandardCharsets.UTF_8));
+        final String requestUri =
+                StringUtils.format(GET_COOKIE_PATH, URLEncoder.encode(TEST_ORIGIN, StandardCharsets.UTF_8));
 
         myWebClient.get(myPort, TestConstants.INADDR_ANY, requestUri).send(get -> {
             if (get.succeeded()) {

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandlerTest.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandlerIT.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,14 +43,14 @@ public final class AccessLevelHandlerIT extends AbstractHandlerIT {
      */
     @Test
     public void testGetAccessLevel(final Vertx aVertx, final VertxTestContext aContext) {
-        final String requestUri = StringUtils.format(GET_ACCESS_LEVEL_PATH,
-                URLEncoder.encode(TEST_ID, StandardCharsets.UTF_8));
+        final String requestUri =
+                StringUtils.format(GET_ACCESS_LEVEL_PATH, URLEncoder.encode(TEST_ID, StandardCharsets.UTF_8));
 
         myWebClient.get(myPort, TestConstants.INADDR_ANY, requestUri).send(get -> {
             if (get.succeeded()) {
                 final HttpResponse<?> response = get.result();
-                final JsonObject expected = new JsonObject().put(ResponseJsonKeys.ID, TEST_ID)
-                        .put(ResponseJsonKeys.RESTRICTED, false);
+                final JsonObject expected =
+                        new JsonObject().put(ResponseJsonKeys.ID, TEST_ID).put(ResponseJsonKeys.RESTRICTED, false);
 
                 assertEquals(HTTP.OK, response.statusCode());
                 assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
@@ -71,17 +72,17 @@ public final class AccessLevelHandlerIT extends AbstractHandlerIT {
     @Test
     public void testGetAccessLevelUnknownItem(final Vertx aVertx, final VertxTestContext aContext) {
         final String id = "ark:/21198/unknown";
-        final String requestUri = StringUtils.format(GET_ACCESS_LEVEL_PATH,
-                URLEncoder.encode(id, StandardCharsets.UTF_8));
+        final String requestUri =
+                StringUtils.format(GET_ACCESS_LEVEL_PATH, URLEncoder.encode(id, StandardCharsets.UTF_8));
 
         myWebClient.get(myPort, TestConstants.INADDR_ANY, requestUri).send(get -> {
             if (get.succeeded()) {
                 final HttpResponse<?> response = get.result();
                 final JsonObject responseBody = response.bodyAsJsonObject();
-                final JsonObject expected = new JsonObject()
-                        .put(ResponseJsonKeys.ERROR, DatabaseServiceError.NOT_FOUND.toString())
-                        .put(ResponseJsonKeys.MESSAGE, LOGGER.getMessage(MessageCodes.AUTH_004, id))
-                        .put(ResponseJsonKeys.ID, id);
+                final JsonObject expected =
+                        new JsonObject().put(ResponseJsonKeys.ERROR, DatabaseServiceError.NOT_FOUND.toString())
+                                .put(ResponseJsonKeys.MESSAGE, LOGGER.getMessage(MessageCodes.AUTH_004, id))
+                                .put(ResponseJsonKeys.ID, id);
 
                 assertEquals(HTTP.NOT_FOUND, response.statusCode());
                 assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessTokenHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessTokenHandlerIT.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,8 +38,8 @@ public final class AccessTokenHandlerIT extends AbstractHandlerIT {
      */
     @Test
     public void testGetToken(final Vertx aVertx, final VertxTestContext aContext) {
-        final String getCookieRequestUri = StringUtils.format("/cookie?origin={}",
-                URLEncoder.encode(TEST_ORIGIN, StandardCharsets.UTF_8));
+        final String getCookieRequestUri =
+                StringUtils.format("/cookie?origin={}", URLEncoder.encode(TEST_ORIGIN, StandardCharsets.UTF_8));
         final HttpRequest<?> getCookie = myWebClient.get(myPort, TestConstants.INADDR_ANY, getCookieRequestUri);
 
         getCookie.send().compose(result -> {
@@ -50,11 +51,11 @@ public final class AccessTokenHandlerIT extends AbstractHandlerIT {
                         .putHeader(HttpHeaders.COOKIE.toString(), cookieHeader);
 
                 return getToken.send().onSuccess(response -> {
-                    final JsonObject expectedAccessTokenDecoded = new JsonObject()
-                            .put(TokenJsonKeys.VERSION, myConfig.getString(Config.HAUTH_VERSION))
-                            .put(TokenJsonKeys.CAMPUS_NETWORK, cookie.getBoolean(CookieJsonKeys.CAMPUS_NETWORK));
-                    final String expectedAccessToken = Base64.getEncoder()
-                            .encodeToString(expectedAccessTokenDecoded.encode().getBytes());
+                    final JsonObject expectedAccessTokenDecoded =
+                            new JsonObject().put(TokenJsonKeys.VERSION, myConfig.getString(Config.HAUTH_VERSION)).put(
+                                    TokenJsonKeys.CAMPUS_NETWORK, cookie.getBoolean(CookieJsonKeys.CAMPUS_NETWORK));
+                    final String expectedAccessToken =
+                            Base64.getEncoder().encodeToString(expectedAccessTokenDecoded.encode().getBytes());
                     final int expectedExpiresIn = myConfig.getInteger(Config.ACCESS_TOKEN_EXPIRES_IN, 3600);
                     final JsonObject expected = new JsonObject().put(ResponseJsonKeys.ACCESS_TOKEN, expectedAccessToken)
                             .put(ResponseJsonKeys.EXPIRES_IN, expectedExpiresIn);

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/StatusHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/StatusHandlerIT.java
@@ -1,3 +1,4 @@
+
 package edu.ucla.library.iiif.auth.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceTest.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceTest.java
@@ -39,8 +39,7 @@ public class AccessCookieServiceTest {
     /**
      * The logger used by these tests.
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(AccessCookieServiceTest.class,
-            MessageCodes.BUNDLE);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccessCookieServiceTest.class, MessageCodes.BUNDLE);
 
     /**
      * The IP address 127.0.0.1.
@@ -72,8 +71,7 @@ public class AccessCookieServiceTest {
                 final ServiceBinder binder = new ServiceBinder(aVertx);
 
                 // Register the service on the event bus, and keep a reference to it so it can be unregistered later
-                myService = binder.setAddress(AccessCookieService.ADDRESS)
-                        .register(AccessCookieService.class, service);
+                myService = binder.setAddress(AccessCookieService.ADDRESS).register(AccessCookieService.class, service);
 
                 // Now we can instantiate a proxy to the service
                 myServiceProxy = AccessCookieService.createProxy(aVertx);
@@ -161,12 +159,12 @@ public class AccessCookieServiceTest {
             aContext.completeNow();
         }).onSuccess(decryptedCookie -> {
             // Somehow we still got syntactically valid JSON; make sure the structure is not semantically valid
-            if (decryptedCookie.containsKey(CookieJsonKeys.CLIENT_IP_ADDRESS)
-                    && decryptedCookie.getString(CookieJsonKeys.CLIENT_IP_ADDRESS).equals(clientIpAddress)
-                    && decryptedCookie.containsKey(CookieJsonKeys.CAMPUS_NETWORK)
-                    && decryptedCookie.getBoolean(CookieJsonKeys.CAMPUS_NETWORK) == isCampusNetwork
-                    && decryptedCookie.containsKey(CookieJsonKeys.DEGRADED_ALLOWED)
-                    && decryptedCookie.getBoolean(CookieJsonKeys.DEGRADED_ALLOWED) == isDegradedAllowed) {
+            if (decryptedCookie.containsKey(CookieJsonKeys.CLIENT_IP_ADDRESS) &&
+                    decryptedCookie.getString(CookieJsonKeys.CLIENT_IP_ADDRESS).equals(clientIpAddress) &&
+                    decryptedCookie.containsKey(CookieJsonKeys.CAMPUS_NETWORK) &&
+                    decryptedCookie.getBoolean(CookieJsonKeys.CAMPUS_NETWORK) == isCampusNetwork &&
+                    decryptedCookie.containsKey(CookieJsonKeys.DEGRADED_ALLOWED) &&
+                    decryptedCookie.getBoolean(CookieJsonKeys.DEGRADED_ALLOWED) == isDegradedAllowed) {
                 aContext.failNow(StringUtils.format(MessageCodes.AUTH_009, decryptedCookie));
             } else {
                 aContext.completeNow();

--- a/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
@@ -134,8 +134,8 @@ public class DatabaseServiceIT {
     final void testGetAccessLevelSetTwice(final VertxTestContext aContext) {
         final String id = "setTwice";
         final int expected = 2;
-        final Future<Void> setTwice = myServiceProxy.setAccessLevel(id, 1)
-                .compose(put -> myServiceProxy.setAccessLevel(id, expected));
+        final Future<Void> setTwice =
+                myServiceProxy.setAccessLevel(id, 1).compose(put -> myServiceProxy.setAccessLevel(id, expected));
 
         setTwice.compose(put -> myServiceProxy.getAccessLevel(id)).onSuccess(result -> {
             completeIfExpectedElseFail(result, expected, aContext);
@@ -209,8 +209,7 @@ public class DatabaseServiceIT {
      * @param aExpected The expected result
      * @param aContext A test context
      */
-    private <T> void completeIfExpectedElseFail(final T aResult, final T aExpected,
-            final VertxTestContext aContext) {
+    private <T> void completeIfExpectedElseFail(final T aResult, final T aExpected, final VertxTestContext aContext) {
         if (aResult.equals(aExpected)) {
             aContext.completeNow();
         } else {


### PR DESCRIPTION
* Set POM version to CI-friendly form
* Update parent project version
* Add auto-formatting Maven plugin
* Include a bunch of formatting changes made by plugin
* Update Maven deployment repo (OSS Sonatype's newer repo)
* Centralize location of versions in POM

Updating the deployment repo and the POM version are the only functional changes.
The rest are cosmetic.

@markmatney There will be some formatting/wrapping changes in here you won't like. I'll keep poking at the formatting rules and see if there is a way to get more control. Fwiw, there is a way to cheat though. If the formatting gives you something like:

```
final JsonObject accessTokenUnencoded =
    new JsonObject().put(TokenJsonKeys.VERSION, myConfig.getString(Config.HAUTH_VERSION)).put(
    TokenJsonKeys.CAMPUS_NETWORK, cookieData.getBoolean(CookieJsonKeys.CAMPUS_NETWORK));
```

You can use comments to force breaks, like:

```
final JsonObject accessTokenUnencoded = new JsonObject() //
    .put(TokenJsonKeys.VERSION, myConfig.getString(Config.HAUTH_VERSION)) //
    .put(TokenJsonKeys.CAMPUS_NETWORK, cookieData.getBoolean(CookieJsonKeys.CAMPUS_NETWORK));
```
Probably slightly more brittle for future edits, but just FYI. It is more readable, IMHO.