### PR TITLE
[SERV-254] Use maven-failsafe-plugin to run integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,7 @@
         </configuration>
         <executions>
 
-          <!-- Builds the Docker images -->
+          <!-- Builds the Hauth Docker image -->
           <execution>
             <id>docker-build</id>
             <phase>pre-integration-test</phase>
@@ -493,7 +493,7 @@
             </configuration>
           </execution>
 
-          <!-- Deploys the Docker image -->
+          <!-- Deploys the Hauth Docker image -->
           <execution>
             <id>docker-deploy</id>
             <phase>deploy</phase>


### PR DESCRIPTION
I don't really like how the logging output of the ITs is now not colorized, but I am at a loss on how to fix that (aside from reverting all these changes).