### PR TITLE
[SERV-320] Add all-or-nothing access mode

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/auth/Op.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/Op.java
@@ -12,9 +12,9 @@ public final class Op {
     public static final String GET_STATUS = "getStatus";
 
     /**
-     * Gets an item's access level.
+     * Gets an item's access mode.
      */
-    public static final String GET_ACCESS_LEVEL = "getAccessLevel";
+    public static final String GET_ACCESS_MODE = "getAccessMode";
 
     /**
      * Gets an authentication cookie.

--- a/src/main/java/edu/ucla/library/iiif/auth/ResponseJsonKeys.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/ResponseJsonKeys.java
@@ -12,9 +12,9 @@ public final class ResponseJsonKeys {
     public static final String STATUS = "status";
 
     /**
-     * The restricted key.
+     * The access mode key.
      */
-    public static final String RESTRICTED = "restricted";
+    public static final String ACCESS_MODE = "accessMode";
 
     /**
      * The error key.

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandler.java
@@ -50,9 +50,9 @@ public class AccessLevelHandler implements Handler<RoutingContext> {
     public void handle(final RoutingContext aContext) {
         final String id = aContext.request().getParam(Param.ID);
 
-        myDatabaseServiceProxy.getAccessLevel(id).onSuccess(accessLevel -> {
+        myDatabaseServiceProxy.getAccessMode(id).onSuccess(accessMode -> {
             final JsonObject data =
-                    new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, AccessMode.values()[accessLevel]);
+                    new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, AccessMode.values()[accessMode]);
 
             aContext.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
                     .setStatusCode(HTTP.OK).end(data.encodePrettily());

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandler.java
@@ -23,7 +23,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.serviceproxy.ServiceException;
 
 /**
- * Handler that handles item access level requests.
+ * Handler that handles item access mode requests.
  */
 public class AccessLevelHandler implements Handler<RoutingContext> {
 
@@ -38,7 +38,7 @@ public class AccessLevelHandler implements Handler<RoutingContext> {
     private final DatabaseService myDatabaseServiceProxy;
 
     /**
-     * Creates a handler that checks the access level of an ID.
+     * Creates a handler that checks the access mode of an ID.
      *
      * @param aVertx The Vert.x instance
      */
@@ -51,7 +51,8 @@ public class AccessLevelHandler implements Handler<RoutingContext> {
         final String id = aContext.request().getParam(Param.ID);
 
         myDatabaseServiceProxy.getAccessLevel(id).onSuccess(accessLevel -> {
-            final JsonObject data = new JsonObject().put(ResponseJsonKeys.RESTRICTED, accessLevel != 0);
+            final JsonObject data =
+                    new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, AccessMode.values()[accessLevel]);
 
             aContext.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
                     .setStatusCode(HTTP.OK).end(data.encodePrettily());
@@ -101,5 +102,12 @@ public class AccessLevelHandler implements Handler<RoutingContext> {
         response.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString()).end(data.encodePrettily());
 
         LOGGER.error(MessageCodes.AUTH_006, request.method(), request.absoluteURI(), responseMessage);
+    }
+
+    /**
+     * FIXME
+     */
+    public enum AccessMode {
+        OPEN, TIERED, ALL_OR_NOTHING;
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandler.java
@@ -51,8 +51,7 @@ public class AccessModeHandler implements Handler<RoutingContext> {
         final String id = aContext.request().getParam(Param.ID);
 
         myDatabaseServiceProxy.getAccessMode(id).onSuccess(accessMode -> {
-            final JsonObject data =
-                    new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, AccessMode.values()[accessMode]);
+            final JsonObject data = new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, AccessMode.values()[accessMode]);
 
             aContext.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
                     .setStatusCode(HTTP.OK).end(data.encodePrettily());

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandler.java
@@ -25,12 +25,12 @@ import io.vertx.serviceproxy.ServiceException;
 /**
  * Handler that handles item access mode requests.
  */
-public class AccessLevelHandler implements Handler<RoutingContext> {
+public class AccessModeHandler implements Handler<RoutingContext> {
 
     /**
      * The handler's logger.
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(AccessLevelHandler.class, MessageCodes.BUNDLE);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccessModeHandler.class, MessageCodes.BUNDLE);
 
     /**
      * The service proxy for accessing the database.
@@ -42,7 +42,7 @@ public class AccessLevelHandler implements Handler<RoutingContext> {
      *
      * @param aVertx The Vert.x instance
      */
-    public AccessLevelHandler(final Vertx aVertx) {
+    public AccessModeHandler(final Vertx aVertx) {
         myDatabaseServiceProxy = DatabaseService.createProxy(aVertx);
     }
 

--- a/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceImpl.java
@@ -148,9 +148,9 @@ public class AccessCookieServiceImpl implements AccessCookieService {
             return Future.failedFuture(new ServiceException(CONFIGURATION_ERROR, details.getMessage()));
         }
 
+        // Vert.x JsonObject knows how to encode/decode byte arrays, so we can use them as-is
         unencodedCookie = new JsonObject().put(CookieJsonKeys.VERSION, myConfig.getString(Config.HAUTH_VERSION))
                 .put(CookieJsonKeys.SECRET, encryptedCookieData).put(CookieJsonKeys.NONCE, myCipher.getIV());
-        // Vert.x JsonObject automatically base64-encodes binary data
         cookie = Base64.getEncoder().encodeToString(unencodedCookie.encode().getBytes());
 
         return Future.succeededFuture(cookie);

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseService.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseService.java
@@ -52,21 +52,21 @@ public interface DatabaseService {
     Future<Void> close();
 
     /**
-     * Gets the "access level" of the item with the given identifier.
+     * Gets the "access mode" of the item with the given identifier.
      *
      * @param aID The item identifier
-     * @return A Future that resolves to the access level once it's been fetched
+     * @return A Future that resolves to the access mode once it's been fetched
      */
-    Future<Integer> getAccessLevel(String aID);
+    Future<Integer> getAccessMode(String aID);
 
     /**
-     * Sets the given "access level" of the item with the given identifier.
+     * Sets the given "access mode" of the item with the given identifier.
      *
      * @param aID The item identifier
-     * @param aAccessLevel The access level to set for the item
-     * @return A Future that resolves once the access level has been set
+     * @param aAccessMode The access mode to set for the item
+     * @return A Future that resolves once the access mode has been set
      */
-    Future<Void> setAccessLevel(String aID, int aAccessLevel);
+    Future<Void> setAccessMode(String aID, int aAccessMode);
 
     /**
      * Gets the "degraded allowed" for content hosted at the given origin.

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
@@ -39,15 +39,15 @@ public class DatabaseServiceImpl implements DatabaseService {
     private static final String POSTGRES = "postgres";
 
     /**
-     * The PreparedQuery template for selecting an item's "access level".
+     * The PreparedQuery template for selecting an item's "access mode".
      */
-    private static final String SELECT_ACCESS_LEVEL = "SELECT access_level FROM items WHERE uid = $1";
+    private static final String SELECT_ACCESS_MODE = "SELECT access_mode FROM items WHERE uid = $1";
 
     /**
-     * The PreparedQuery template for upserting an item's "access level".
+     * The PreparedQuery template for upserting an item's "access mode".
      */
-    private static final String UPSERT_ACCESS_LEVEL = String.join(SPACE, "INSERT INTO items VALUES ($1, $2)",
-            "ON CONFLICT (uid) DO", "UPDATE SET access_level = EXCLUDED.access_level");
+    private static final String UPSERT_ACCESS_MODE = String.join(SPACE, "INSERT INTO items VALUES ($1, $2)",
+            "ON CONFLICT (uid) DO", "UPDATE SET access_mode = EXCLUDED.access_mode");
 
     /**
      * The PreparedQuery template for selecting an origin's "degraded allowed".
@@ -103,14 +103,14 @@ public class DatabaseServiceImpl implements DatabaseService {
     }
 
     @Override
-    public Future<Integer> getAccessLevel(final String aID) {
+    public Future<Integer> getAccessMode(final String aID) {
         return myDbConnectionPool.withConnection(connection -> {
-            return connection.preparedQuery(SELECT_ACCESS_LEVEL).execute(Tuple.of(aID));
+            return connection.preparedQuery(SELECT_ACCESS_MODE).execute(Tuple.of(aID));
         }).recover(error -> {
             return Future.failedFuture(new ServiceException(INTERNAL_ERROR, error.getMessage()));
         }).compose(select -> {
             if (hasSingleRow(select)) {
-                return Future.succeededFuture(select.iterator().next().getInteger("access_level"));
+                return Future.succeededFuture(select.iterator().next().getInteger("access_mode"));
             } else {
                 return Future.failedFuture(new ServiceException(NOT_FOUND_ERROR, aID));
             }
@@ -118,9 +118,9 @@ public class DatabaseServiceImpl implements DatabaseService {
     }
 
     @Override
-    public Future<Void> setAccessLevel(final String aID, final int aAccessLevel) {
+    public Future<Void> setAccessMode(final String aID, final int aAccessMode) {
         return myDbConnectionPool.withConnection(connection -> {
-            return connection.preparedQuery(UPSERT_ACCESS_LEVEL).execute(Tuple.of(aID, aAccessLevel));
+            return connection.preparedQuery(UPSERT_ACCESS_MODE).execute(Tuple.of(aID, aAccessMode));
         }).recover(error -> {
             return Future.failedFuture(new ServiceException(INTERNAL_ERROR, error.getMessage()));
         }).compose(result -> Future.succeededFuture());

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
@@ -76,7 +76,7 @@ public class DatabaseServiceImpl implements DatabaseService {
     private static final int NOT_FOUND_ERROR = DatabaseServiceError.NOT_FOUND.ordinal();
 
     /**
-     * The underlying SQL client.
+     * The underlying PostgreSQL connection pool.
      */
     private final PgPool myDbConnectionPool;
 

--- a/src/main/java/edu/ucla/library/iiif/auth/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/verticles/MainVerticle.java
@@ -10,7 +10,7 @@ import edu.ucla.library.iiif.auth.Config;
 import edu.ucla.library.iiif.auth.MessageCodes;
 import edu.ucla.library.iiif.auth.Op;
 import edu.ucla.library.iiif.auth.handlers.AccessCookieHandler;
-import edu.ucla.library.iiif.auth.handlers.AccessLevelHandler;
+import edu.ucla.library.iiif.auth.handlers.AccessModeHandler;
 import edu.ucla.library.iiif.auth.handlers.AccessTokenHandler;
 import edu.ucla.library.iiif.auth.handlers.StatusHandler;
 import edu.ucla.library.iiif.auth.services.AccessCookieService;
@@ -98,8 +98,8 @@ public class MainVerticle extends AbstractVerticle {
 
                 // Associate handlers with operation IDs from the OpenAPI spec
                 routerBuilder.operation(Op.GET_STATUS).handler(new StatusHandler(getVertx()));
-                routerBuilder.operation(Op.GET_ACCESS_MODE).handler(new AccessLevelHandler(getVertx()))
-                        .failureHandler(AccessLevelHandler::handleFailure);
+                routerBuilder.operation(Op.GET_ACCESS_MODE).handler(new AccessModeHandler(getVertx()))
+                        .failureHandler(AccessModeHandler::handleFailure);
                 routerBuilder.operation(Op.GET_COOKIE).handler(new AccessCookieHandler(getVertx(), config));
                 routerBuilder.operation(Op.GET_TOKEN).handler(new AccessTokenHandler(getVertx(), config))
                         .failureHandler(AccessTokenHandler::handleFailure);

--- a/src/main/java/edu/ucla/library/iiif/auth/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/verticles/MainVerticle.java
@@ -98,7 +98,7 @@ public class MainVerticle extends AbstractVerticle {
 
                 // Associate handlers with operation IDs from the OpenAPI spec
                 routerBuilder.operation(Op.GET_STATUS).handler(new StatusHandler(getVertx()));
-                routerBuilder.operation(Op.GET_ACCESS_LEVEL).handler(new AccessLevelHandler(getVertx()))
+                routerBuilder.operation(Op.GET_ACCESS_MODE).handler(new AccessLevelHandler(getVertx()))
                         .failureHandler(AccessLevelHandler::handleFailure);
                 routerBuilder.operation(Op.GET_COOKIE).handler(new AccessCookieHandler(getVertx(), config));
                 routerBuilder.operation(Op.GET_TOKEN).handler(new AccessTokenHandler(getVertx(), config))

--- a/src/main/resources/hauth.yaml
+++ b/src/main/resources/hauth.yaml
@@ -9,27 +9,27 @@ servers:
 paths:
   /access/{id}:
     get:
-      summary: Get Supplied ID's Access Control Level
-      description: Whether the supplied ID has open or restricted access
-      operationId: getAccessLevel
+      summary: Get Supplied ID's access mode
+      description: Whether the supplied ID's access mode is open, tiered, or all-or-nothing
+      operationId: getAccessMode
       parameters:
         - in: path
           name: id
-          description: The ID whose access level we want to check
+          description: The ID whose access mode we want to check
           schema:
             type: string
           required: true
       responses:
         '200':
-          description: The information about the supplied ID's access control level
+          description: The information about the supplied ID's access mode
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  restricted:
-                    type: boolean
-                    example: true
+                  accessMode:
+                    type: string
+                    example: OPEN
         '404':
           description: Notification that the supplied ID couldn't be found
           content:
@@ -55,7 +55,7 @@ paths:
                     example: INTERNAL
                   message:
                     type: string
-                    example: The service failed to connect to its access control database
+                    example: The service failed to connect to its database
   /cookie:
     get:
       summary: Get Authentication Cookie
@@ -73,7 +73,7 @@ paths:
           description: The cookie gets set in the response that includes Javascript to close the open tab/window
           headers:
             Set-Cookie:
-              description: An encrypted cookie value that contains the supplied origin and level of allowed access
+              description: An encrypted cookie value that contains the supplied origin and access mode
               schema:
                 type: string
                 example: iiifauth=asrvaaDe43AAqw34QpOoPJR4j5b1; Path=/; HttpOnly

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AbstractHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AbstractHandlerIT.java
@@ -41,9 +41,9 @@ public abstract class AbstractHandlerIT {
     protected static final String GET_TOKEN_PATH = "/token?{}";
 
     /**
-     * The URI path template for access level requests.
+     * The URI path template for access mode requests.
      */
-    protected static final String GET_ACCESS_LEVEL_PATH = "/access/{}";
+    protected static final String GET_ACCESS_MODE_PATH = "/access/{}";
 
     /**
      * The URI path template for access cookie requests.
@@ -100,8 +100,8 @@ public abstract class AbstractHandlerIT {
     public void setUp(final Vertx aVertx, final VertxTestContext aContext) {
         ConfigRetriever.create(aVertx).getConfig().compose(config -> {
             final DatabaseService db = DatabaseService.create(aVertx, config);
-            final List<Future> dbOps = List.of(db.setAccessLevel(TEST_ID_OPEN_ACCESS, 0),
-                    db.setAccessLevel(TEST_ID_TIERED_ACCESS, 1), db.setAccessLevel(TEST_ID_ALL_OR_NOTHING_ACCESS, 2),
+            final List<Future> dbOps = List.of(db.setAccessMode(TEST_ID_OPEN_ACCESS, 0),
+                    db.setAccessMode(TEST_ID_TIERED_ACCESS, 1), db.setAccessMode(TEST_ID_ALL_OR_NOTHING_ACCESS, 2),
                     db.setDegradedAllowed(TEST_ORIGIN, false));
 
             myConfig = config;

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandlerIT.java
@@ -36,19 +36,65 @@ public final class AccessLevelHandlerIT extends AbstractHandlerIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(AccessLevelHandlerIT.class, MessageCodes.BUNDLE);
 
     /**
-     * Tests that a client can get an item's access level.
+     * Tests that a client can get the access mode of an item with open access.
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
      */
     @Test
-    public void testGetAccessLevel(final Vertx aVertx, final VertxTestContext aContext) {
-        final String requestURI =
-                StringUtils.format(GET_ACCESS_LEVEL_PATH, URLEncoder.encode(TEST_ID, StandardCharsets.UTF_8));
+    public void testGetAccessLevelOpen(final Vertx aVertx, final VertxTestContext aContext) {
+        final String requestURI = StringUtils.format(GET_ACCESS_LEVEL_PATH,
+                URLEncoder.encode(TEST_ID_OPEN_ACCESS, StandardCharsets.UTF_8));
         final HttpRequest<?> getAccessLevel = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestURI);
 
         getAccessLevel.send().onSuccess(response -> {
-            final JsonObject expected = new JsonObject().put(ResponseJsonKeys.RESTRICTED, false);
+            final JsonObject expected = new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, "OPEN"); // FIXME
+
+            assertEquals(HTTP.OK, response.statusCode());
+            assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+            assertEquals(expected, response.bodyAsJsonObject());
+
+            aContext.completeNow();
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that a client can get the access mode of an item with tiered access.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testGetAccessLevelTiered(final Vertx aVertx, final VertxTestContext aContext) {
+        final String requestUri = StringUtils.format(GET_ACCESS_LEVEL_PATH,
+                URLEncoder.encode(TEST_ID_TIERED_ACCESS, StandardCharsets.UTF_8));
+        final HttpRequest<?> getAccessLevel = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestUri);
+
+        getAccessLevel.send().onSuccess(response -> {
+            final JsonObject expected = new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, "TIERED");
+
+            assertEquals(HTTP.OK, response.statusCode());
+            assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+            assertEquals(expected, response.bodyAsJsonObject());
+
+            aContext.completeNow();
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that a client can get the access mode of an item with all-or-nothing access.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testGetAccessLevelAllOrNothing(final Vertx aVertx, final VertxTestContext aContext) {
+        final String requestUri = StringUtils.format(GET_ACCESS_LEVEL_PATH,
+                URLEncoder.encode(TEST_ID_ALL_OR_NOTHING_ACCESS, StandardCharsets.UTF_8));
+        final HttpRequest<?> getAccessLevel = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestUri);
+
+        getAccessLevel.send().onSuccess(response -> {
+            final JsonObject expected = new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, "ALL_OR_NOTHING");
 
             assertEquals(HTTP.OK, response.statusCode());
             assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessLevelHandlerIT.java
@@ -42,12 +42,12 @@ public final class AccessLevelHandlerIT extends AbstractHandlerIT {
      * @param aContext A test context
      */
     @Test
-    public void testGetAccessLevelOpen(final Vertx aVertx, final VertxTestContext aContext) {
-        final String requestURI = StringUtils.format(GET_ACCESS_LEVEL_PATH,
+    public void testGetAccessModeOpen(final Vertx aVertx, final VertxTestContext aContext) {
+        final String requestURI = StringUtils.format(GET_ACCESS_MODE_PATH,
                 URLEncoder.encode(TEST_ID_OPEN_ACCESS, StandardCharsets.UTF_8));
-        final HttpRequest<?> getAccessLevel = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestURI);
+        final HttpRequest<?> getAccessMode = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestURI);
 
-        getAccessLevel.send().onSuccess(response -> {
+        getAccessMode.send().onSuccess(response -> {
             final JsonObject expected = new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, "OPEN"); // FIXME
 
             assertEquals(HTTP.OK, response.statusCode());
@@ -65,12 +65,12 @@ public final class AccessLevelHandlerIT extends AbstractHandlerIT {
      * @param aContext A test context
      */
     @Test
-    public void testGetAccessLevelTiered(final Vertx aVertx, final VertxTestContext aContext) {
-        final String requestUri = StringUtils.format(GET_ACCESS_LEVEL_PATH,
+    public void testGetAccessModeTiered(final Vertx aVertx, final VertxTestContext aContext) {
+        final String requestUri = StringUtils.format(GET_ACCESS_MODE_PATH,
                 URLEncoder.encode(TEST_ID_TIERED_ACCESS, StandardCharsets.UTF_8));
-        final HttpRequest<?> getAccessLevel = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestUri);
+        final HttpRequest<?> getAccessMode = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestUri);
 
-        getAccessLevel.send().onSuccess(response -> {
+        getAccessMode.send().onSuccess(response -> {
             final JsonObject expected = new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, "TIERED");
 
             assertEquals(HTTP.OK, response.statusCode());
@@ -88,12 +88,12 @@ public final class AccessLevelHandlerIT extends AbstractHandlerIT {
      * @param aContext A test context
      */
     @Test
-    public void testGetAccessLevelAllOrNothing(final Vertx aVertx, final VertxTestContext aContext) {
-        final String requestUri = StringUtils.format(GET_ACCESS_LEVEL_PATH,
+    public void testGetAccessModeAllOrNothing(final Vertx aVertx, final VertxTestContext aContext) {
+        final String requestUri = StringUtils.format(GET_ACCESS_MODE_PATH,
                 URLEncoder.encode(TEST_ID_ALL_OR_NOTHING_ACCESS, StandardCharsets.UTF_8));
-        final HttpRequest<?> getAccessLevel = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestUri);
+        final HttpRequest<?> getAccessMode = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestUri);
 
-        getAccessLevel.send().onSuccess(response -> {
+        getAccessMode.send().onSuccess(response -> {
             final JsonObject expected = new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, "ALL_OR_NOTHING");
 
             assertEquals(HTTP.OK, response.statusCode());
@@ -105,23 +105,23 @@ public final class AccessLevelHandlerIT extends AbstractHandlerIT {
     }
 
     /**
-     * Tests that a client gets the expected error response when requesting the access level of an unknown item.
+     * Tests that a client gets the expected error response when requesting the access mode of an unknown item.
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
      */
     @Test
-    public void testGetAccessLevelUnknownItem(final Vertx aVertx, final VertxTestContext aContext) {
+    public void testGetAccessModeUnknownItem(final Vertx aVertx, final VertxTestContext aContext) {
         final String id = "ark:/21198/unknown";
         final String requestURI =
-                StringUtils.format(GET_ACCESS_LEVEL_PATH, URLEncoder.encode(id, StandardCharsets.UTF_8));
-        final HttpRequest<?> getAccessLevel = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestURI);
+                StringUtils.format(GET_ACCESS_MODE_PATH, URLEncoder.encode(id, StandardCharsets.UTF_8));
+        final HttpRequest<?> getAccessMode = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestURI);
 
-        getAccessLevel.send().onSuccess(response -> {
+        getAccessMode.send().onSuccess(response -> {
             final JsonObject responseBody = response.bodyAsJsonObject();
             final JsonObject expected =
                     new JsonObject().put(ResponseJsonKeys.ERROR, DatabaseServiceError.NOT_FOUND.toString())
-                            .put(ResponseJsonKeys.MESSAGE, LOGGER.getMessage(MessageCodes.AUTH_004, id));
+                    .put(ResponseJsonKeys.MESSAGE, LOGGER.getMessage(MessageCodes.AUTH_004, id));
 
             assertEquals(HTTP.NOT_FOUND, response.statusCode());
             assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandlerIT.java
@@ -121,7 +121,7 @@ public final class AccessModeHandlerIT extends AbstractHandlerIT {
             final JsonObject responseBody = response.bodyAsJsonObject();
             final JsonObject expected =
                     new JsonObject().put(ResponseJsonKeys.ERROR, DatabaseServiceError.NOT_FOUND.toString())
-                    .put(ResponseJsonKeys.MESSAGE, LOGGER.getMessage(MessageCodes.AUTH_004, id));
+                            .put(ResponseJsonKeys.MESSAGE, LOGGER.getMessage(MessageCodes.AUTH_004, id));
 
             assertEquals(HTTP.NOT_FOUND, response.statusCode());
             assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandlerIT.java
@@ -26,14 +26,14 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.junit5.VertxTestContext;
 
 /**
- * Tests {@link AccessLevelHandler#handle}.
+ * Tests {@link AccessModeHandler#handle}.
  */
-public final class AccessLevelHandlerIT extends AbstractHandlerIT {
+public final class AccessModeHandlerIT extends AbstractHandlerIT {
 
     /**
      * The test's logger.
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(AccessLevelHandlerIT.class, MessageCodes.BUNDLE);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccessModeHandlerIT.class, MessageCodes.BUNDLE);
 
     /**
      * Tests that a client can get the access mode of an item with open access.

--- a/src/test/java/edu/ucla/library/iiif/auth/services/AbstractServiceTest.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/AbstractServiceTest.java
@@ -1,0 +1,41 @@
+
+package edu.ucla.library.iiif.auth.services;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.iiif.auth.MessageCodes;
+
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * A base class for service tests.
+ */
+@ExtendWith(VertxExtension.class)
+public abstract class AbstractServiceTest {
+
+    /**
+     * The logger used by these tests.
+     */
+    private static Logger LOGGER = LoggerFactory.getLogger(AbstractServiceTest.class, MessageCodes.BUNDLE);
+
+    /**
+     * Completes the context if the actual result and the expected result are equal, otherwise fails the context.
+     *
+     * @param <T> The type of result
+     * @param aResult The actual result
+     * @param aExpected The expected result
+     * @param aContext A test context
+     */
+    public static <T> void completeIfExpectedElseFail(final T aResult, final T aExpected,
+            final VertxTestContext aContext) {
+        if (aResult.equals(aExpected)) {
+            aContext.completeNow();
+        } else {
+            aContext.failNow(LOGGER.getMessage(MessageCodes.AUTH_007, aResult, aExpected));
+        }
+    }
+}

--- a/src/test/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceTest.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceTest.java
@@ -34,7 +34,7 @@ import io.vertx.serviceproxy.ServiceException;
  * Tests the {@link AccessCookieService}.
  */
 @ExtendWith(VertxExtension.class)
-public class AccessCookieServiceTest {
+public class AccessCookieServiceTest extends AbstractServiceTest {
 
     /**
      * The logger used by these tests.
@@ -174,21 +174,5 @@ public class AccessCookieServiceTest {
 
     protected Logger getLogger() {
         return LOGGER;
-    }
-
-    /**
-     * Completes the context if the actual result and the expected result are equal, otherwise fails the context.
-     *
-     * @param <T> The type of result
-     * @param aResult The actual result
-     * @param aExpected The expected result
-     * @param aContext A test context
-     */
-    private <T> void completeIfExpectedElseFail(final T aResult, final T aExpected, final VertxTestContext aContext) {
-        if (aResult.equals(aExpected)) {
-            aContext.completeNow();
-        } else {
-            aContext.failNow(LOGGER.getMessage(MessageCodes.AUTH_007, aResult, aExpected));
-        }
     }
 }

--- a/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
@@ -18,7 +17,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.serviceproxy.ServiceBinder;
 import io.vertx.serviceproxy.ServiceException;
@@ -26,8 +24,7 @@ import io.vertx.serviceproxy.ServiceException;
 /**
  * A test of the database connection.
  */
-@ExtendWith(VertxExtension.class)
-public class DatabaseServiceIT {
+public class DatabaseServiceIT extends AbstractServiceTest {
 
     /**
      * The logger used by these tests.
@@ -126,7 +123,7 @@ public class DatabaseServiceIT {
     }
 
     /**
-     * Tests reading an item whose "access level" that has been set more than once.
+     * Tests reading an item whose "access level" has been set more than once.
      *
      * @param aContext A test context
      */
@@ -199,21 +196,5 @@ public class DatabaseServiceIT {
 
     protected Logger getLogger() {
         return LOGGER;
-    }
-
-    /**
-     * Completes the context if the actual result and the expected result are equal, otherwise fails the context.
-     *
-     * @param <T> The type of result
-     * @param aResult The actual result
-     * @param aExpected The expected result
-     * @param aContext A test context
-     */
-    private <T> void completeIfExpectedElseFail(final T aResult, final T aExpected, final VertxTestContext aContext) {
-        if (aResult.equals(aExpected)) {
-            aContext.completeNow();
-        } else {
-            aContext.failNow(LOGGER.getMessage(MessageCodes.AUTH_007, aResult, aExpected));
-        }
     }
 }

--- a/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
@@ -79,20 +79,20 @@ public class DatabaseServiceIT extends AbstractServiceTest {
     public final void tearDown(final Vertx aVertx, final VertxTestContext aContext) {
         // Close the service proxy, then unregister the service (order important)
         myServiceProxy.close().compose(result -> myService.unregister()).onSuccess(success -> aContext.completeNow())
-                .onFailure(aContext::failNow);
+        .onFailure(aContext::failNow);
     }
 
     /**
-     * Tests reading an item whose "access level" has not been set.
+     * Tests reading an item whose "access mode" has not been set.
      *
      * @param aContext A test context
      */
     @Test
-    final void testGetAccessLevelUnset(final VertxTestContext aContext) {
+    final void testGetAccessModeUnset(final VertxTestContext aContext) {
         final String id = "unset";
         final String expected = NULL;
 
-        myServiceProxy.getAccessLevel(id).onFailure(details -> {
+        myServiceProxy.getAccessMode(id).onFailure(details -> {
             // The get should fail since nothing has been set for the id
             final ServiceException error = (ServiceException) details;
 
@@ -107,34 +107,34 @@ public class DatabaseServiceIT extends AbstractServiceTest {
     }
 
     /**
-     * Tests reading an item whose "access level" has been set once.
+     * Tests reading an item whose "access mode" has been set once.
      *
      * @param aContext A test context
      */
     @Test
-    final void testGetAccessLevelSetOnce(final VertxTestContext aContext) {
+    final void testGetAccessModeSetOnce(final VertxTestContext aContext) {
         final String id = "setOnce";
         final int expected = 1;
-        final Future<Void> setOnce = myServiceProxy.setAccessLevel(id, expected);
+        final Future<Void> setOnce = myServiceProxy.setAccessMode(id, expected);
 
-        setOnce.compose(put -> myServiceProxy.getAccessLevel(id)).onSuccess(result -> {
+        setOnce.compose(put -> myServiceProxy.getAccessMode(id)).onSuccess(result -> {
             completeIfExpectedElseFail(result, expected, aContext);
         }).onFailure(aContext::failNow);
     }
 
     /**
-     * Tests reading an item whose "access level" has been set more than once.
+     * Tests reading an item whose "access mode" has been set more than once.
      *
      * @param aContext A test context
      */
     @Test
-    final void testGetAccessLevelSetTwice(final VertxTestContext aContext) {
+    final void testGetAccessModeSetTwice(final VertxTestContext aContext) {
         final String id = "setTwice";
         final int expected = 2;
         final Future<Void> setTwice =
-                myServiceProxy.setAccessLevel(id, 1).compose(put -> myServiceProxy.setAccessLevel(id, expected));
+                myServiceProxy.setAccessMode(id, 1).compose(put -> myServiceProxy.setAccessMode(id, expected));
 
-        setTwice.compose(put -> myServiceProxy.getAccessLevel(id)).onSuccess(result -> {
+        setTwice.compose(put -> myServiceProxy.getAccessMode(id)).onSuccess(result -> {
             completeIfExpectedElseFail(result, expected, aContext);
         }).onFailure(aContext::failNow);
     }

--- a/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
@@ -79,7 +79,7 @@ public class DatabaseServiceIT extends AbstractServiceTest {
     public final void tearDown(final Vertx aVertx, final VertxTestContext aContext) {
         // Close the service proxy, then unregister the service (order important)
         myServiceProxy.close().compose(result -> myService.unregister()).onSuccess(success -> aContext.completeNow())
-        .onFailure(aContext::failNow);
+                .onFailure(aContext::failNow);
     }
 
     /**

--- a/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
@@ -149,15 +149,16 @@ public class DatabaseServiceIT extends AbstractServiceTest {
         final String url = "https://library.ucla.edu";
         final String expected = NULL;
 
-        myServiceProxy.getDegradedAllowed(url).onSuccess(result -> {
-            completeIfExpectedElseFail(result, expected, aContext);
-        }).onFailure(details -> {
+        myServiceProxy.getDegradedAllowed(url).onFailure(details -> {
             final ServiceException error = (ServiceException) details;
 
             assertEquals(DatabaseServiceError.NOT_FOUND, DatabaseServiceImpl.getError(error));
             assertEquals(url, error.getMessage());
 
             aContext.completeNow();
+        }).onSuccess(result -> {
+            // The following will always fail
+            completeIfExpectedElseFail(result, expected, aContext);
         });
     }
 

--- a/src/test/resources/db/authzdb.sql
+++ b/src/test/resources/db/authzdb.sql
@@ -38,7 +38,7 @@ SET default_table_access_method = heap;
 
 CREATE TABLE public.items (
     uid text NOT NULL,
-    access_level smallint DEFAULT 0 NOT NULL
+    access_mode smallint DEFAULT 0 NOT NULL
 );
 
 CREATE TABLE public.origins (
@@ -57,10 +57,10 @@ ALTER TABLE public.origins OWNER TO postgres;
 COMMENT ON COLUMN public.items.uid IS 'The unique identifier of the requested object';
 
 --
--- Name: COLUMN items.access_level; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN items.access_mode; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.items.access_level IS 'The access level of the requested item: 0 is open, 1 is restricted to UCLA affiliates';
+COMMENT ON COLUMN public.items.access_mode IS 'The access mode of the requested item: 0 is open, 1 is restricted to UCLA affiliates';
 
 --
 -- Name: COLUMN origins.url; Type: COMMENT; Schema: public; Owner: postgres
@@ -79,7 +79,7 @@ COMMENT ON COLUMN public.origins.degraded_allowed IS 'Whether this origin allows
 -- Name: items; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.items (uid, access_level) FROM stdin;
+COPY public.items (uid, access_mode) FROM stdin;
 \.
 
 --


### PR DESCRIPTION
Changes:
- allow /access/{id} endpoint to return more than two possible values; proposing strings (e.g. OPEN, TIERED) rather than ints (e.g. 0, 1) since they're IMO more meaningful
- call it "access mode" instead of "access level" per discussion with @ksclarke
- test helper de-duplication and comment improvements