### PR TITLE
[SERV-335] Fix build issue; update dependencies

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+#
+# This file contains a list of project codeowners
+#
+
+* @UCLALibrary/services-team-reviewers

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
 
     <!-- Application dependencies -->
     <freelib.utils.version>3.0.1</freelib.utils.version>
-    <slf4j.ext.version>1.7.30</slf4j.ext.version>
     <cidr.ip.version>1.0.1</cidr.ip.version>
     <commons.codec.version>1.15</commons.codec.version>
     <vertx.version>4.2.4</vertx.version>
@@ -64,7 +63,7 @@
     <junit.version>5.8.0-M1</junit.version>
     <redis.version>6.2.5-alpine</redis.version>
     <postgres.version>12.7-alpine</postgres.version>
-    <cantaloupe.version>5.0.3-0</cantaloupe.version>
+    <cantaloupe.version>5.0.4-1</cantaloupe.version>
     <auth.delegate.version>0.0.1-SNAPSHOT</auth.delegate.version>
     <jsoup.version>1.14.3</jsoup.version>
 
@@ -163,13 +162,6 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>${commons.codec.version}</version>
-    </dependency>
-
-    <!-- Below is a dependency that needs updating due to security issue (may be able to remove in future) -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-      <version>${slf4j.ext.version}</version>
     </dependency>
 
     <!-- A Vert.x plug-in for more flexible configuration control -->
@@ -393,6 +385,7 @@
                   </bind>
                 </volumes>
                 <env>
+                  <CANTALOUPE_LOG_APPLICATION_LEVEL>info</CANTALOUPE_LOG_APPLICATION_LEVEL>
                   <CANTALOUPE_ENDPOINT_ADMIN_SECRET>secret</CANTALOUPE_ENDPOINT_ADMIN_SECRET>
                   <CANTALOUPE_ENDPOINT_ADMIN_ENABLED>true</CANTALOUPE_ENDPOINT_ADMIN_ENABLED>
                   <CANTALOUPE_DELEGATE_SCRIPT_ENABLED>true</CANTALOUPE_DELEGATE_SCRIPT_ENABLED>

--- a/pom.xml
+++ b/pom.xml
@@ -43,19 +43,19 @@
     <native.compile>false</native.compile>
 
     <!-- Application dependencies -->
-    <freelib.utils.version>2.4.0</freelib.utils.version>
+    <freelib.utils.version>3.0.1</freelib.utils.version>
     <slf4j.ext.version>1.7.30</slf4j.ext.version>
     <cidr.ip.version>1.0.1</cidr.ip.version>
     <commons.codec.version>1.15</commons.codec.version>
-    <vertx.version>4.2.3</vertx.version>
+    <vertx.version>4.2.4</vertx.version>
 
     <!-- Build plugin versions -->
     <clean.plugin.version>3.1.0</clean.plugin.version>
     <jar.plugin.version>3.2.0</jar.plugin.version>
-    <vertx.plugin.version>1.0.24</vertx.plugin.version>
+    <vertx.plugin.version>1.0.27</vertx.plugin.version>
     <freelib.maven.version>0.3.0</freelib.maven.version>
     <deploy.plugin.version>3.0.0-M1</deploy.plugin.version>
-    <docker.maven.plugin.version>0.36.0</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.38.1</docker.maven.plugin.version>
     <!-- Failsafe 3.x has compatibility issues with JUnit 5: https://stackoverflow.com/a/51837961 -->
     <maven.failsafe.plugin.version>2.22.0</maven.failsafe.plugin.version>
 
@@ -607,6 +607,7 @@
                 <configuration>
                   <args>
                     <arg>--org=${env.UCLALIBRARY_SNYK_ORG}</arg>
+                    <arg>--fail-on=all</arg>
                   </args>
                 </configuration>
               </execution>


### PR DESCRIPTION
* Fix Snyk issue preventing successful builds
* Update dependency versions
* Remove an obsolete dependency segregation (slf4-ext)
* Update the version of Cantaloupe used to 5.0.4-1
* Fix a timeout issue with the startup of Cantaloupe in the integration testing.


The Snyk plugin doesn't seem to be inheriting the `--fail-on` configuration from the parent project, but if we add the config directly to this project it works.

The newer version of Cantaloupe no longer outputs INFO logs by default, which is what we were using to match on for the indicator that the Docker container had been successfully started.