### PR TITLE
[IIIF-1242] Make internal error enum name more specific

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandler.java
@@ -90,7 +90,7 @@ public class AccessModeHandler implements Handler<RoutingContext> {
                 response.setStatusCode(HTTP.NOT_FOUND);
                 responseMessage = LOGGER.getMessage(MessageCodes.AUTH_004, id);
                 break;
-            case INTERNAL:
+            case INTERNAL_ERROR:
             default:
                 response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
                 responseMessage = LOGGER.getMessage(MessageCodes.AUTH_005);

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceError.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceError.java
@@ -6,7 +6,7 @@ package edu.ucla.library.iiif.auth.services;
  */
 public enum DatabaseServiceError {
     // The failure code if the service is unable to query the underlying database.
-    INTERNAL,
+    INTERNAL_ERROR,
 
     // The failure code if the service receives a get request for an unknown id or origin.
     NOT_FOUND;

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
@@ -66,9 +66,9 @@ public class DatabaseServiceImpl implements DatabaseService {
     private static final String DEFAULT_HOSTNAME = "localhost";
 
     /**
-     * The failure code to use for a ServiceException that represents {@link DatabaseServiceError#INTERNAL}.
+     * The failure code to use for a ServiceException that represents {@link DatabaseServiceError#INTERNAL_ERROR}.
      */
-    private static final int INTERNAL_ERROR = DatabaseServiceError.INTERNAL.ordinal();
+    private static final int INTERNAL_ERROR = DatabaseServiceError.INTERNAL_ERROR.ordinal();
 
     /**
      * The failure code to use for a ServiceException that represents {@link DatabaseServiceError#NOT_FOUND}.

--- a/src/main/resources/hauth.yaml
+++ b/src/main/resources/hauth.yaml
@@ -54,8 +54,8 @@ paths:
                 properties:
                   error:
                     type: string
-                    enum: [ INTERNAL ]
-                    example: INTERNAL
+                    enum: [ INTERNAL_ERROR ]
+                    example: INTERNAL_ERROR
                   message:
                     type: string
                     example: The service failed to connect to its database


### PR DESCRIPTION
I'm guessing DatabaseServiceError.INTERNAL was originally named as such because DatabaseServiceError.INTERNAL_ERROR felt like repetition. I think the latter is clearer though because it is used in places without the class name (e.g., in the hauth.yaml OpenAPI spec or AccessModeHandler's switch). This PR suggests using the more explicit name so it's clearer what it is. I came across this while working on documentation using the hauth.yaml file.