### PR TITLE
[SERV-347] Add API endpoint for importing items

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ These are a work in progress. Randomized ports and passwords are created on the 
 | ENV Property | Default Value | Required |
 | --- | --- | --- |
 | ACCESS_TOKEN_EXPIRES_IN | 3600 | No |
+| API_KEY | XXXX | Yes |
 | API_SPEC | hauth.yaml | No |
 | CAMPUS_NETWORK_SUBNETS | XXX | Yes |
 | DB_CACHE_HOST | localhost | No |

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,15 @@
             </configuration>
           </execution>
           <execution>
+            <id>generate-api-key</id>
+            <goals>
+              <goal>set-uuid-property</goal>
+            </goals>
+            <configuration>
+              <name>test.api.key</name>
+            </configuration>
+          </execution>
+          <execution>
             <id>set-snapshot-url</id>
             <goals>
               <goal>set-snapshot-url</goal>
@@ -436,6 +445,7 @@
                   <port>${test.http.port}:8888</port>
                 </ports>
                 <env>
+                  <API_KEY>${test.api.key}</API_KEY>
                   <!-- This particular choice of subnets is arbitrary -->
                   <CAMPUS_NETWORK_SUBNETS>127.0.0.0/24,192.168.0.0/24</CAMPUS_NETWORK_SUBNETS>
                   <DB_CACHE_PORT>${test.db.cache.port}</DB_CACHE_PORT>
@@ -546,6 +556,7 @@
         <configuration>
           <argLine>${jacoco.agent.arg}</argLine>
           <environmentVariables>
+            <API_KEY>${test.api.key}</API_KEY>
             <DB_CACHE_PORT>${test.db.cache.port}</DB_CACHE_PORT>
             <DB_PASSWORD>${test.db.password}</DB_PASSWORD>
             <DB_PORT>${test.db.port}</DB_PORT>

--- a/src/main/java/edu/ucla/library/iiif/auth/AdminAuthenticationProvider.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/AdminAuthenticationProvider.java
@@ -1,0 +1,51 @@
+
+package edu.ucla.library.iiif.auth;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authentication.AuthenticationProvider;
+import io.vertx.ext.auth.authentication.TokenCredentials;
+
+/**
+ * An admin API authentication provider.
+ */
+public class AdminAuthenticationProvider implements AuthenticationProvider {
+
+    /**
+     * The the authentication provider's logger.
+     */
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(AdminAuthenticationProvider.class, MessageCodes.BUNDLE);
+
+    /**
+     * The application configuration.
+     */
+    private final JsonObject myConfig;
+
+    /**
+     * Creates an authentication provider for admin APIs.
+     *
+     * @param aConfig A configuration
+     */
+    public AdminAuthenticationProvider(final JsonObject aConfig) {
+        myConfig = aConfig;
+    }
+
+    @Override
+    public void authenticate(final JsonObject aCredentialsJson, final Handler<AsyncResult<User>> aResultHandler) {
+        final String apiKey = new TokenCredentials(aCredentialsJson).getToken();
+
+        if (myConfig.getValue(Config.API_KEY).equals(apiKey)) {
+            aResultHandler.handle(Future.succeededFuture(User.fromToken(apiKey)));
+        } else {
+            aResultHandler.handle(Future.failedFuture(LOGGER.getMessage(MessageCodes.AUTH_016)));
+        }
+    }
+
+}

--- a/src/main/java/edu/ucla/library/iiif/auth/Config.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/Config.java
@@ -33,6 +33,11 @@ public final class Config {
     public static final String API_SPEC = "API_SPEC";
 
     /**
+     * The ENV property for the API key for private endpoints.
+     */
+    public static final String API_KEY = "API_KEY";
+
+    /**
      * The ENV property for the database password.
      */
     public static final String DB_PASSWORD = "DB_PASSWORD";

--- a/src/main/java/edu/ucla/library/iiif/auth/Error.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/Error.java
@@ -5,5 +5,5 @@ package edu.ucla.library.iiif.auth;
  * Possible application errors not associated with any of our service implementations.
  */
 public enum Error {
-    HTML_RENDERING_ERROR, INVALID_JSONARRAY_ERROR;
+    HTML_RENDERING_ERROR, INVALID_JSONARRAY, INVALID_ADMIN_CREDENTIALS;
 }

--- a/src/main/java/edu/ucla/library/iiif/auth/Error.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/Error.java
@@ -5,5 +5,5 @@ package edu.ucla.library.iiif.auth;
  * Possible application errors not associated with any of our service implementations.
  */
 public enum Error {
-    HTML_RENDERING_ERROR;
+    HTML_RENDERING_ERROR, INVALID_JSONARRAY_ERROR;
 }

--- a/src/main/java/edu/ucla/library/iiif/auth/Op.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/Op.java
@@ -32,6 +32,11 @@ public final class Op {
     public static final String GET_TOKEN_SINAI = "getTokenSinai";
 
     /**
+     * Sets items.
+     */
+    public static final String POST_ITEMS = "postItems";
+
+    /**
      * Constant class constructors should be private.
      */
     private Op() {

--- a/src/main/java/edu/ucla/library/iiif/auth/RequestJsonKeys.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/RequestJsonKeys.java
@@ -1,0 +1,24 @@
+
+package edu.ucla.library.iiif.auth;
+
+/**
+ * A constants class for JSON keys expected in POST request bodies.
+ */
+public final class RequestJsonKeys {
+
+    /**
+     * The uid key.
+     */
+    public static final String UID = "uid";
+
+    /**
+     * The access mode key.
+     */
+    public static final String ACCESS_MODE = "accessMode";
+
+    /**
+     * Private constructor for utility class.
+     */
+    private RequestJsonKeys() {
+    }
+}

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AbstractAccessTokenHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AbstractAccessTokenHandler.java
@@ -152,8 +152,7 @@ public abstract class AbstractAccessTokenHandler implements Handler<RoutingConte
         try {
             error = (ServiceException) aContext.failure();
         } catch (final ClassCastException details) {
-            aContext.fail(HTTP.INTERNAL_SERVER_ERROR, details);
-            LOGGER.error(MessageCodes.AUTH_010, details);
+            aContext.next();
             return;
         }
 

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandler.java
@@ -74,8 +74,7 @@ public class AccessModeHandler implements Handler<RoutingContext> {
         try {
             error = (ServiceException) aContext.failure();
         } catch (final ClassCastException details) {
-            aContext.fail(HTTP.INTERNAL_SERVER_ERROR, details);
-            LOGGER.error(MessageCodes.AUTH_010, details);
+            aContext.next();
             return;
         }
 

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AdminAuthenticationErrorHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AdminAuthenticationErrorHandler.java
@@ -1,0 +1,59 @@
+
+package edu.ucla.library.iiif.auth.handlers;
+
+import info.freelibrary.util.HTTP;
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.util.StringUtils;
+
+import edu.ucla.library.iiif.auth.Error;
+import edu.ucla.library.iiif.auth.ResponseJsonKeys;
+import edu.ucla.library.iiif.auth.MessageCodes;
+import edu.ucla.library.iiif.auth.utils.MediaType;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.ErrorHandler;
+import io.vertx.ext.web.handler.HttpException;
+
+/**
+ * Handles admin API authentication errors.
+ */
+public class AdminAuthenticationErrorHandler implements ErrorHandler {
+
+    /**
+     * The handler's logger.
+     */
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(AdminAuthenticationErrorHandler.class, MessageCodes.BUNDLE);
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final Throwable error = aContext.failure();
+
+        if (error instanceof HttpException) {
+            final HttpException details = (HttpException) error;
+            final int statusCode = details.getStatusCode();
+
+            final HttpServerResponse response =
+                    aContext.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString());
+            final JsonObject responseBody = new JsonObject();
+
+            response.setStatusCode(statusCode);
+
+            if (statusCode == HTTP.UNAUTHORIZED) {
+                responseBody.put(ResponseJsonKeys.ERROR, Error.INVALID_ADMIN_CREDENTIALS).put(ResponseJsonKeys.MESSAGE,
+                        LOGGER.getMessage(MessageCodes.AUTH_016));
+            } else {
+                responseBody.put(ResponseJsonKeys.ERROR, StringUtils.format("HTTP {}", statusCode))
+                        .put(ResponseJsonKeys.MESSAGE, details.getMessage());
+            }
+
+            response.end(responseBody.encodePrettily());
+        } else {
+            aContext.next();
+        }
+    }
+}

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/ItemsHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/ItemsHandler.java
@@ -56,7 +56,7 @@ public class ItemsHandler implements Handler<RoutingContext> {
             requestData = aContext.getBodyAsJsonArray();
         } catch (final DecodeException details) {
             final JsonObject error = new JsonObject() //
-                    .put(ResponseJsonKeys.ERROR, Error.INVALID_JSONARRAY_ERROR) //
+                    .put(ResponseJsonKeys.ERROR, Error.INVALID_JSONARRAY) //
                     .put(ResponseJsonKeys.MESSAGE, details.getMessage());
 
             aContext.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
@@ -85,8 +85,7 @@ public class ItemsHandler implements Handler<RoutingContext> {
         try {
             error = (ServiceException) aContext.failure();
         } catch (final ClassCastException details) {
-            aContext.fail(HTTP.INTERNAL_SERVER_ERROR, details);
-            LOGGER.error(MessageCodes.AUTH_010, details);
+            aContext.next();
             return;
         }
 

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/ItemsHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/ItemsHandler.java
@@ -58,7 +58,9 @@ public class ItemsHandler implements Handler<RoutingContext> {
             final JsonObject error = new JsonObject() //
                     .put(ResponseJsonKeys.ERROR, Error.INVALID_JSONARRAY_ERROR) //
                     .put(ResponseJsonKeys.MESSAGE, details.getMessage());
-            aContext.response().setStatusCode(HTTP.BAD_REQUEST).end(error.encodePrettily());
+
+            aContext.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
+                    .setStatusCode(HTTP.BAD_REQUEST).end(error.encodePrettily());
             return;
         }
 

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/ItemsHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/ItemsHandler.java
@@ -1,0 +1,114 @@
+
+package edu.ucla.library.iiif.auth.handlers;
+
+import info.freelibrary.util.HTTP;
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.iiif.auth.Error;
+import edu.ucla.library.iiif.auth.MessageCodes;
+import edu.ucla.library.iiif.auth.ResponseJsonKeys;
+import edu.ucla.library.iiif.auth.services.DatabaseService;
+import edu.ucla.library.iiif.auth.services.DatabaseServiceError;
+import edu.ucla.library.iiif.auth.services.DatabaseServiceImpl;
+import edu.ucla.library.iiif.auth.utils.MediaType;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.serviceproxy.ServiceException;
+
+/**
+ * Handler that handles items requests.
+ */
+public class ItemsHandler implements Handler<RoutingContext> {
+
+    /**
+     * The handler's logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(ItemsHandler.class, MessageCodes.BUNDLE);
+
+    /**
+     * The service proxy for accessing the database.
+     */
+    private final DatabaseService myDatabaseServiceProxy;
+
+    /**
+     * Creates a handler that adds items to the database.
+     *
+     * @param aVertx The Vert.x instance
+     */
+    public ItemsHandler(final Vertx aVertx) {
+        myDatabaseServiceProxy = DatabaseService.createProxy(aVertx);
+    }
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final JsonArray requestData;
+
+        try {
+            requestData = aContext.getBodyAsJsonArray();
+        } catch (final DecodeException details) {
+            final JsonObject error = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, Error.INVALID_JSONARRAY_ERROR) //
+                    .put(ResponseJsonKeys.MESSAGE, details.getMessage());
+            aContext.response().setStatusCode(HTTP.BAD_REQUEST).end(error.encodePrettily());
+            return;
+        }
+
+        myDatabaseServiceProxy.setItems(requestData).onSuccess(result -> {
+            aContext.response().setStatusCode(HTTP.CREATED).end();
+        }).onFailure(aContext::fail);
+    }
+
+    /**
+     * Handle failure events sent by {@link #handle}.
+     *
+     * @param aContext the failure event to handle
+     */
+    public static void handleFailure(final RoutingContext aContext) {
+        final ServiceException error;
+        final HttpServerRequest request;
+        final HttpServerResponse response;
+        final String responseMessage;
+        final JsonObject data;
+        final DatabaseServiceError errorCode;
+
+        try {
+            error = (ServiceException) aContext.failure();
+        } catch (final ClassCastException details) {
+            aContext.fail(HTTP.INTERNAL_SERVER_ERROR, details);
+            LOGGER.error(MessageCodes.AUTH_010, details);
+            return;
+        }
+
+        request = aContext.request();
+        response = aContext.response();
+        data = new JsonObject();
+        errorCode = DatabaseServiceImpl.getError(error);
+
+        switch (errorCode) {
+            case MALFORMED_INPUT_DATA:
+                final String msg = error.getMessage();
+                response.setStatusCode(HTTP.BAD_REQUEST);
+                responseMessage = LOGGER.getMessage(MessageCodes.AUTH_014, msg);
+                break;
+            case INTERNAL_ERROR:
+            default:
+                response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
+                responseMessage = LOGGER.getMessage(MessageCodes.AUTH_005);
+                break;
+        }
+
+        data.put(ResponseJsonKeys.ERROR, errorCode).put(ResponseJsonKeys.MESSAGE, responseMessage);
+        response.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString()).end(data.encodePrettily());
+
+        LOGGER.error(MessageCodes.AUTH_006, request.method(), request.absoluteURI(), responseMessage);
+    }
+}

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseService.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseService.java
@@ -6,6 +6,7 @@ import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ServiceProxyBuilder;
 
@@ -67,6 +68,14 @@ public interface DatabaseService {
      * @return A Future that resolves once the access mode has been set
      */
     Future<Void> setAccessMode(String aID, int aAccessMode);
+
+    /**
+     * Sets the given items.
+     *
+     * @param aItems An array of objects that can be deserialized to a list of {@link DatabaseServiceImpl.Item}
+     * @return A Future that resolves once the items have been set
+     */
+    Future<Void> setItems(JsonArray aItems);
 
     /**
      * Gets the "degraded allowed" for content hosted at the given origin.

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceError.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceError.java
@@ -9,5 +9,8 @@ public enum DatabaseServiceError {
     INTERNAL_ERROR,
 
     // The failure code if the service receives a get request for an unknown id or origin.
-    NOT_FOUND;
+    NOT_FOUND,
+
+    // The failure code if the service receives a post request with malformed data.
+    MALFORMED_INPUT_DATA;
 }

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
@@ -149,7 +149,7 @@ public class DatabaseServiceImpl implements DatabaseService {
 
     @Override
     public Future<Void> setItems(final JsonArray aItems) {
-        return getPreparedQueryTuples(aItems, myMapper).compose(tuples -> {
+        return getPreparedQueryTuples(aItems).compose(tuples -> {
             return myDbConnectionPool.withConnection(connection -> {
                 return connection.preparedQuery(UPSERT_ACCESS_MODE).executeBatch(tuples);
             }).recover(error -> {
@@ -261,16 +261,15 @@ public class DatabaseServiceImpl implements DatabaseService {
     /**
      * Gets a list of Tuples for executing a PreparedQuery.
      *
-     * @param aJsonArray
-     * @param aMapper
+     * @param aJsonArray A JSON representation of a list of items
      * @return A Future that either resolves to the list of tuples, or fails if the input data is malformed
      */
-    private static Future<List<Tuple>> getPreparedQueryTuples(final JsonArray aJsonArray, final ObjectMapper aMapper) {
+    private Future<List<Tuple>> getPreparedQueryTuples(final JsonArray aJsonArray) {
         final List<Tuple> itemList = new ArrayList<>();
 
         for (final Object item : aJsonArray.stream().collect(Collectors.toList())) {
             try {
-                itemList.add(Item.create((JsonObject) item, aMapper).toPreparedQueryTuple());
+                itemList.add(Item.create((JsonObject) item, myMapper).toPreparedQueryTuple());
             } catch (final JsonProcessingException details) {
                 return Future.failedFuture(details);
             }

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
@@ -132,9 +132,8 @@ public class DatabaseServiceImpl implements DatabaseService {
         }).compose(select -> {
             if (hasSingleRow(select)) {
                 return Future.succeededFuture(select.iterator().next().getInteger("access_mode"));
-            } else {
-                return Future.failedFuture(new ServiceException(NOT_FOUND_ERROR, aID));
             }
+            return Future.failedFuture(new ServiceException(NOT_FOUND_ERROR, aID));
         });
     }
 
@@ -172,9 +171,8 @@ public class DatabaseServiceImpl implements DatabaseService {
         }).compose(select -> {
             if (hasSingleRow(select)) {
                 return Future.succeededFuture(select.iterator().next().getBoolean("degraded_allowed"));
-            } else {
-                return Future.failedFuture(new ServiceException(NOT_FOUND_ERROR, aOrigin));
             }
+            return Future.failedFuture(new ServiceException(NOT_FOUND_ERROR, aOrigin));
         });
     }
 

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
@@ -18,6 +18,7 @@ import info.freelibrary.util.StringUtils;
 
 import edu.ucla.library.iiif.auth.Config;
 import edu.ucla.library.iiif.auth.MessageCodes;
+import edu.ucla.library.iiif.auth.RequestJsonKeys;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -300,8 +301,8 @@ public class DatabaseServiceImpl implements DatabaseService {
          * @param anAccessMode The access mode to use for the item
          */
         @JsonCreator
-        private Item(@JsonProperty(value = "uid", required = true) final String aUID,
-                @JsonProperty(value = "accessMode", required = true) final int anAccessMode) {
+        private Item(@JsonProperty(value = RequestJsonKeys.UID, required = true) final String aUID,
+                @JsonProperty(value = RequestJsonKeys.ACCESS_MODE, required = true) final int anAccessMode) {
             myUID = aUID;
             myAccessMode = anAccessMode;
         }

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseServiceImpl.java
@@ -249,16 +249,6 @@ public class DatabaseServiceImpl implements DatabaseService {
     }
 
     /**
-     * Checks if the given RowSet consists of a single row or not.
-     *
-     * @param aRowSet A RowSet representing the response to a database query
-     * @return true if it has a single row, false otherwise
-     */
-    private static boolean hasSingleRow(final RowSet<Row> aRowSet) {
-        return aRowSet.rowCount() == 1;
-    }
-
-    /**
      * Gets a list of Tuples for executing a PreparedQuery.
      *
      * @param aJsonArray A JSON representation of a list of items
@@ -276,6 +266,16 @@ public class DatabaseServiceImpl implements DatabaseService {
         }
 
         return Future.succeededFuture(itemList);
+    }
+
+    /**
+     * Checks if the given RowSet consists of a single row or not.
+     *
+     * @param aRowSet A RowSet representing the response to a database query
+     * @return true if it has a single row, false otherwise
+     */
+    private static boolean hasSingleRow(final RowSet<Row> aRowSet) {
+        return aRowSet.rowCount() == 1;
     }
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/auth/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/verticles/MainVerticle.java
@@ -3,26 +3,22 @@ package edu.ucla.library.iiif.auth.verticles;
 
 import java.security.GeneralSecurityException;
 
-import info.freelibrary.util.HTTP;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
-import info.freelibrary.util.StringUtils;
 
 import edu.ucla.library.iiif.auth.AdminAuthenticationProvider;
 import edu.ucla.library.iiif.auth.Config;
-import edu.ucla.library.iiif.auth.Error;
 import edu.ucla.library.iiif.auth.MessageCodes;
 import edu.ucla.library.iiif.auth.Op;
-import edu.ucla.library.iiif.auth.ResponseJsonKeys;
 import edu.ucla.library.iiif.auth.handlers.AccessCookieHandler;
 import edu.ucla.library.iiif.auth.handlers.AccessModeHandler;
 import edu.ucla.library.iiif.auth.handlers.AccessTokenHandler;
+import edu.ucla.library.iiif.auth.handlers.AdminAuthenticationErrorHandler;
 import edu.ucla.library.iiif.auth.handlers.ItemsHandler;
 import edu.ucla.library.iiif.auth.handlers.SinaiAccessTokenHandler;
 import edu.ucla.library.iiif.auth.handlers.StatusHandler;
 import edu.ucla.library.iiif.auth.services.AccessCookieService;
 import edu.ucla.library.iiif.auth.services.DatabaseService;
-import edu.ucla.library.iiif.auth.utils.MediaType;
 
 import io.vertx.config.ConfigRetriever;
 import io.vertx.core.AbstractVerticle;
@@ -30,21 +26,17 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.eventbus.MessageConsumer;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.APIKeyHandler;
-import io.vertx.ext.web.handler.HttpException;
 import io.vertx.ext.web.openapi.RouterBuilder;
 import io.vertx.serviceproxy.ServiceBinder;
 
 /**
  * Main verticle that starts the application.
  */
-@SuppressWarnings({ "PMD.ExcessiveImports" })
 public class MainVerticle extends AbstractVerticle {
 
     /**
@@ -128,32 +120,7 @@ public class MainVerticle extends AbstractVerticle {
                 router = routerBuilder.createRouter();
 
                 // Handle authentication errors on admin routes
-                router.route().failureHandler(aContext -> {
-                    final Throwable throwable = aContext.failure();
-
-                    if (throwable instanceof HttpException) {
-                        final HttpException error = (HttpException) throwable;
-                        final int statusCode = error.getStatusCode();
-
-                        final HttpServerResponse response = aContext.response().putHeader(HttpHeaders.CONTENT_TYPE,
-                                MediaType.APPLICATION_JSON.toString());
-                        final JsonObject responseBody = new JsonObject();
-
-                        response.setStatusCode(statusCode);
-
-                        if (statusCode == HTTP.UNAUTHORIZED) {
-                            responseBody.put(ResponseJsonKeys.ERROR, Error.INVALID_ADMIN_CREDENTIALS)
-                                    .put(ResponseJsonKeys.MESSAGE, LOGGER.getMessage(MessageCodes.AUTH_016));
-                        } else {
-                            responseBody.put(ResponseJsonKeys.ERROR, StringUtils.format("HTTP {}", statusCode))
-                                    .put(ResponseJsonKeys.MESSAGE, error.getMessage());
-                        }
-
-                        response.end(responseBody.encodePrettily());
-                    } else {
-                        aContext.next();
-                    }
-                });
+                router.route().failureHandler(new AdminAuthenticationErrorHandler());
 
                 return Future.succeededFuture(router);
             }).compose(router -> {

--- a/src/main/java/edu/ucla/library/iiif/auth/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/verticles/MainVerticle.java
@@ -12,6 +12,7 @@ import edu.ucla.library.iiif.auth.Op;
 import edu.ucla.library.iiif.auth.handlers.AccessCookieHandler;
 import edu.ucla.library.iiif.auth.handlers.AccessModeHandler;
 import edu.ucla.library.iiif.auth.handlers.AccessTokenHandler;
+import edu.ucla.library.iiif.auth.handlers.ItemsHandler;
 import edu.ucla.library.iiif.auth.handlers.SinaiAccessTokenHandler;
 import edu.ucla.library.iiif.auth.handlers.StatusHandler;
 import edu.ucla.library.iiif.auth.services.AccessCookieService;
@@ -106,6 +107,8 @@ public class MainVerticle extends AbstractVerticle {
                         .failureHandler(AccessTokenHandler::handleFailure);
                 routerBuilder.operation(Op.GET_TOKEN_SINAI).handler(new SinaiAccessTokenHandler(getVertx(), config))
                         .failureHandler(SinaiAccessTokenHandler::handleFailure);
+                routerBuilder.operation(Op.POST_ITEMS).handler(new ItemsHandler(getVertx()))
+                        .failureHandler(ItemsHandler::handleFailure);
 
                 // Finally, spin up the HTTP server
                 return server.requestHandler(routerBuilder.createRouter()).listen();

--- a/src/main/resources/hauth.yaml
+++ b/src/main/resources/hauth.yaml
@@ -6,6 +6,12 @@ info:
     name: The 3-Clause BSD License
 servers:
 - url: http://github.com/uclalibrary/hauth
+components:
+  securitySchemes:
+    Admin:
+      type: apiKey
+      in: header
+      name: X-API-KEY
 paths:
   /access/{id}:
     get:
@@ -268,6 +274,8 @@ paths:
       summary: Add Items
       description: Adds items to the database
       operationId: postItems
+      security:
+        - Admin: []
       requestBody:
         content:
           application/json:
@@ -284,8 +292,21 @@ paths:
                 properties:
                   error:
                     type: string
-                    enum: [ INVALID_JSONARRAY_ERROR, MALFORMED_INPUT_DATA ]
+                    enum: [ INVALID_JSONARRAY, MALFORMED_INPUT_DATA ]
                     example: MALFORMED_INPUT_DATA
+                  message:
+                    type: string
+        '401':
+          description: API key is missing or invalid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum: [ INVALID_ADMIN_CREDENTIALS ]
+                    example: INVALID_ADMIN_CREDENTIALS
                   message:
                     type: string
         '500':

--- a/src/main/resources/hauth.yaml
+++ b/src/main/resources/hauth.yaml
@@ -263,3 +263,41 @@ paths:
                     example: ok
         '500':
           description: There was an internal server error
+  /items:
+    post:
+      summary: Add Items
+      description: Adds items to the database
+      operationId: postItems
+      requestBody:
+        content:
+          application/json:
+            example: [ { "uid": "ark:/21198/00000000", "accessMode": 0 }, { "uid": "ark:/21198/11111111", "accessMode": 1 } ]
+      responses:
+        '201':
+          description: The items have been successfully added
+        '400':
+          description: The request didn't contain valid data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum: [ INVALID_JSONARRAY_ERROR, MALFORMED_INPUT_DATA ]
+                    example: MALFORMED_INPUT_DATA
+                  message:
+                    type: string
+        '500':
+          description: There was an internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum: [ INTERNAL_ERROR ]
+                    example: INTERNAL_ERROR
+                  message:
+                    type: string

--- a/src/main/resources/hauth_messages.xml
+++ b/src/main/resources/hauth_messages.xml
@@ -19,5 +19,6 @@
   <entry key="AUTH_011">The request did not contain a valid cookie</entry>
   <entry key="AUTH_012">The access cookie could not be decoded</entry>
   <entry key="AUTH_013">Expected the client's IP address ({}) to match what's in the cookie it sent ({})</entry>
+  <entry key="AUTH_015">Expected adding items to fail, but it succeeded: {}</entry>
 
 </properties>

--- a/src/main/resources/hauth_messages.xml
+++ b/src/main/resources/hauth_messages.xml
@@ -21,5 +21,6 @@
   <entry key="AUTH_013">Expected the client's IP address ({}) to match what's in the cookie it sent ({})</entry>
   <entry key="AUTH_014">Malformed input data: {}</entry>
   <entry key="AUTH_015">Expected adding items to fail, but it succeeded: {}</entry>
+  <entry key="AUTH_016">API key is missing or invalid</entry>
 
 </properties>

--- a/src/main/resources/hauth_messages.xml
+++ b/src/main/resources/hauth_messages.xml
@@ -19,6 +19,7 @@
   <entry key="AUTH_011">The request did not contain a valid cookie</entry>
   <entry key="AUTH_012">The access cookie could not be decoded</entry>
   <entry key="AUTH_013">Expected the client's IP address ({}) to match what's in the cookie it sent ({})</entry>
+  <entry key="AUTH_014">Malformed input data: {}</entry>
   <entry key="AUTH_015">Expected adding items to fail, but it succeeded: {}</entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AbstractHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AbstractHandlerIT.java
@@ -56,6 +56,11 @@ public abstract class AbstractHandlerIT {
     protected static final String GET_COOKIE_PATH = "/cookie?origin={}";
 
     /**
+     * The URI path for items requests.
+     */
+    protected static final String POST_ITEMS_PATH = "/items";
+
+    /**
      * A test id for an item with open access.
      */
     protected static final String TEST_ID_OPEN_ACCESS = "ark:/21198/00000000";

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/ItemsHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/ItemsHandlerIT.java
@@ -119,6 +119,7 @@ public final class ItemsHandlerIT extends AbstractHandlerIT {
 
         postItems.sendJson(TEST_ITEM_OPEN_ACCESS).onSuccess(response -> {
             assertEquals(HTTP.BAD_REQUEST, response.statusCode());
+            assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
             assertEquals(Error.INVALID_JSONARRAY_ERROR.toString(),
                     response.bodyAsJsonObject().getString(ResponseJsonKeys.ERROR));
 
@@ -139,6 +140,7 @@ public final class ItemsHandlerIT extends AbstractHandlerIT {
 
         postItems.sendJson(json).onSuccess(response -> {
             assertEquals(HTTP.BAD_REQUEST, response.statusCode());
+            assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
             assertEquals(DatabaseServiceError.MALFORMED_INPUT_DATA.toString(),
                     response.bodyAsJsonObject().getString(ResponseJsonKeys.ERROR));
 

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/ItemsHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/ItemsHandlerIT.java
@@ -77,10 +77,11 @@ public final class ItemsHandlerIT extends AbstractHandlerIT {
         postItems.sendJson(json).compose(response -> {
             final String getAccessModeRequestUri1 =
                     StringUtils.format(GET_ACCESS_MODE_PATH, URLEncoder.encode(TEST_ID_1, StandardCharsets.UTF_8));
-            final HttpRequest<?> getAccessMode1 =
-                    myWebClient.get(myPort, TestConstants.INADDR_ANY, getAccessModeRequestUri1);
             final String getAccessModeRequestUri2 =
                     StringUtils.format(GET_ACCESS_MODE_PATH, URLEncoder.encode(TEST_ID_2, StandardCharsets.UTF_8));
+
+            final HttpRequest<?> getAccessMode1 =
+                    myWebClient.get(myPort, TestConstants.INADDR_ANY, getAccessModeRequestUri1);
             final HttpRequest<?> getAccessMode2 =
                     myWebClient.get(myPort, TestConstants.INADDR_ANY, getAccessModeRequestUri2);
 

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/ItemsHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/ItemsHandlerIT.java
@@ -1,0 +1,148 @@
+
+package edu.ucla.library.iiif.auth.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import info.freelibrary.util.HTTP;
+import info.freelibrary.util.StringUtils;
+
+import edu.ucla.library.iiif.auth.Error;
+import edu.ucla.library.iiif.auth.RequestJsonKeys;
+import edu.ucla.library.iiif.auth.ResponseJsonKeys;
+import edu.ucla.library.iiif.auth.handlers.AccessModeHandler.AccessMode;
+import edu.ucla.library.iiif.auth.services.DatabaseServiceError;
+import edu.ucla.library.iiif.auth.utils.MediaType;
+import edu.ucla.library.iiif.auth.utils.TestConstants;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Tests {@link ItemsHandler#handle}.
+ */
+public final class ItemsHandlerIT extends AbstractHandlerIT {
+
+    /**
+     * A test ID.
+     */
+    private static final String TEST_ID_1 = "ark:/12345/00000000";
+
+    /**
+     * A test ID.
+     */
+    private static final String TEST_ID_2 = "ark:/12345/11111111";
+
+    /**
+     * Example valid JSON representation of an open access item.
+     */
+    private static final JsonObject TEST_ITEM_OPEN_ACCESS = new JsonObject() //
+            .put(RequestJsonKeys.UID, TEST_ID_1) //
+            .put(RequestJsonKeys.ACCESS_MODE, 0);
+
+    /**
+     * Example valid JSON representation of a tiered access item.
+     */
+    private static final JsonObject TEST_ITEM_TIERED_ACCESS = new JsonObject() //
+            .put(RequestJsonKeys.UID, TEST_ID_2) //
+            .put(RequestJsonKeys.ACCESS_MODE, 1);
+
+    /**
+     * Example invalid JSON representation of an item (missing access mode).
+     */
+    private static final JsonObject TEST_ITEM_MISSING_ACCESS_MODE = new JsonObject() //
+            .put(RequestJsonKeys.UID, TEST_ID_1);
+
+    /**
+     * Tests that items can be POSTed.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testPostItems(final Vertx aVertx, final VertxTestContext aContext) {
+        final HttpRequest<?> postItems = myWebClient.post(myPort, TestConstants.INADDR_ANY, POST_ITEMS_PATH);
+        final JsonArray json = new JsonArray().add(TEST_ITEM_OPEN_ACCESS).add(TEST_ITEM_TIERED_ACCESS);
+
+        postItems.sendJson(json).compose(response -> {
+            final String getAccessModeRequestUri1 =
+                    StringUtils.format(GET_ACCESS_MODE_PATH, URLEncoder.encode(TEST_ID_1, StandardCharsets.UTF_8));
+            final HttpRequest<?> getAccessMode1 =
+                    myWebClient.get(myPort, TestConstants.INADDR_ANY, getAccessModeRequestUri1);
+            final String getAccessModeRequestUri2 =
+                    StringUtils.format(GET_ACCESS_MODE_PATH, URLEncoder.encode(TEST_ID_2, StandardCharsets.UTF_8));
+            final HttpRequest<?> getAccessMode2 =
+                    myWebClient.get(myPort, TestConstants.INADDR_ANY, getAccessModeRequestUri2);
+
+            assertEquals(HTTP.CREATED, response.statusCode());
+
+            return CompositeFuture.all(getAccessMode1.send(), getAccessMode2.send());
+        }).onSuccess(responses -> {
+            final HttpResponse<?> response1 = responses.<HttpResponse<?>>resultAt(0);
+            final HttpResponse<?> response2 = responses.<HttpResponse<?>>resultAt(1);
+
+            final JsonObject expected1 = new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, AccessMode.OPEN);
+            final JsonObject expected2 = new JsonObject().put(ResponseJsonKeys.ACCESS_MODE, AccessMode.TIERED);
+
+            assertEquals(HTTP.OK, response1.statusCode());
+            assertEquals(HTTP.OK, response2.statusCode());
+
+            assertEquals(MediaType.APPLICATION_JSON.toString(), response1.headers().get(HttpHeaders.CONTENT_TYPE));
+            assertEquals(MediaType.APPLICATION_JSON.toString(), response2.headers().get(HttpHeaders.CONTENT_TYPE));
+
+            assertEquals(expected1, response1.bodyAsJsonObject());
+            assertEquals(expected2, response2.bodyAsJsonObject());
+
+            aContext.completeNow();
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that the request body must be a JSON array, not a JSON object (or anything else).
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testPostItemsInvalidRequestBody(final Vertx aVertx, final VertxTestContext aContext) {
+        final HttpRequest<?> postItems = myWebClient.post(myPort, TestConstants.INADDR_ANY, POST_ITEMS_PATH);
+
+        postItems.sendJson(TEST_ITEM_OPEN_ACCESS).onSuccess(response -> {
+            assertEquals(HTTP.BAD_REQUEST, response.statusCode());
+            assertEquals(Error.INVALID_JSONARRAY_ERROR.toString(),
+                    response.bodyAsJsonObject().getString(ResponseJsonKeys.ERROR));
+
+            aContext.completeNow();
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that the request is rejected if any of the items are missing a key.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testPostItemsMissingKey(final Vertx aVertx, final VertxTestContext aContext) {
+        final HttpRequest<?> postItems = myWebClient.post(myPort, TestConstants.INADDR_ANY, POST_ITEMS_PATH);
+        final JsonArray json = new JsonArray().add(TEST_ITEM_OPEN_ACCESS).add(TEST_ITEM_MISSING_ACCESS_MODE);
+
+        postItems.sendJson(json).onSuccess(response -> {
+            assertEquals(HTTP.BAD_REQUEST, response.statusCode());
+            assertEquals(DatabaseServiceError.MALFORMED_INPUT_DATA.toString(),
+                    response.bodyAsJsonObject().getString(ResponseJsonKeys.ERROR));
+
+            aContext.completeNow();
+        }).onFailure(aContext::failNow);
+    }
+}

--- a/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
@@ -3,19 +3,24 @@ package edu.ucla.library.iiif.auth.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.util.StringUtils;
 
 import edu.ucla.library.iiif.auth.MessageCodes;
 
 import io.vertx.config.ConfigRetriever;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.serviceproxy.ServiceBinder;
@@ -137,6 +142,49 @@ public class DatabaseServiceIT extends AbstractServiceTest {
         setTwice.compose(put -> myServiceProxy.getAccessMode(id)).onSuccess(result -> {
             completeIfExpectedElseFail(result, expected, aContext);
         }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests setting multiple items at once.
+     *
+     * @param aContext A test context
+     */
+    @Test
+    final void testSetItems(final VertxTestContext aContext) {
+        final String id1 = "setItems1";
+        final String id2 = "setItems2";
+        final int expected1 = 1;
+        final int expected2 = 2;
+        final String items = StringUtils.format(
+                "[ { \"uid\": \"{}\", \"accessMode\": {} }, { \"uid\": \"{}\", \"accessMode\": {} } ]", id1, expected1,
+                id2, expected2);
+        final Future<Void> setItems = myServiceProxy.setItems(new JsonArray(items));
+
+        setItems.compose(multi -> {
+            return CompositeFuture.all(myServiceProxy.getAccessMode(id1), myServiceProxy.getAccessMode(id2));
+        }).onSuccess(compositeResult -> {
+            completeIfExpectedElseFail(
+                    List.of(compositeResult.<Integer>resultAt(0), compositeResult.<Integer>resultAt(1)),
+                    List.of(expected1, expected2), aContext);
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that setting multiple items at once fails if any of the item JSON objects are invalid.
+     *
+     * @param aContext A test context
+     */
+    @Test
+    final void testSetItemsInvalidItem(final VertxTestContext aContext) {
+        final String itemsMissingAccessMode = "[ { \"uid\": \"setItemsInvalidItem\" } ]";
+        final Future<Void> setItems = myServiceProxy.setItems(new JsonArray(itemsMissingAccessMode));
+
+        setItems.onFailure(result -> {
+            completeIfExpectedElseFail(DatabaseServiceError.MALFORMED_INPUT_DATA,
+                    DatabaseServiceImpl.getError((ServiceException) result), aContext);
+        }).onSuccess(result -> {
+            aContext.failNow(LOGGER.getMessage(MessageCodes.AUTH_015, result));
+        });
     }
 
     /**

--- a/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
@@ -160,7 +160,7 @@ public class DatabaseServiceIT extends AbstractServiceTest {
                 id2, expected2);
         final Future<Void> setItems = myServiceProxy.setItems(new JsonArray(items));
 
-        setItems.compose(multi -> {
+        setItems.compose(result -> {
             return CompositeFuture.all(myServiceProxy.getAccessMode(id1), myServiceProxy.getAccessMode(id2));
         }).onSuccess(compositeResult -> {
             completeIfExpectedElseFail(


### PR DESCRIPTION
Related to https://github.com/UCLALibrary/hauth/pull/30. Note the new `setItems` method on `DatabaseService` which implements a multi-valued insert/update query. Also, one lingering question I have is how to handle authentication, since obviously this new API shouldn't be public.