### PR TITLE
[SERV-373] Check the expiration date of the Sinai access cookie

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -42,6 +42,12 @@ RUN if [ "${NATIVE_COMPILE}" = true ] ; then \
     && chown hauth:hauth /usr/bin/hauth \
     && chmod 750 /usr/bin/hauth
 
+# Required so that the current date is always the same from the perspective of both the container and Maven
+# TODO: the Sinai cookie should contain a more specific timestamp so that setting the system time is not strictly necessary
+RUN apk add alpine-conf \
+    && setup-timezone -z America/Los_Angeles \
+    && apk del alpine-conf
+
 # The user that runs the hauth application
 USER hauth
 

--- a/src/main/resources/hauth_messages.xml
+++ b/src/main/resources/hauth_messages.xml
@@ -24,5 +24,7 @@
   <entry key="AUTH_016">API key is missing or invalid</entry>
   <entry key="AUTH_017">Could not render HTML response for {} {}</entry>
   <entry key="AUTH_018">Internal error</entry>
+  <entry key="AUTH_019">Expected validation of expired cookie to fail, but it succeeded</entry>
+  <entry key="AUTH_020">Generated cookies: {}={}, {}={} (cleartext: "{}")</entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/iiif/auth/utils/TestConstants.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/utils/TestConstants.java
@@ -4,39 +4,9 @@ package edu.ucla.library.iiif.auth.utils;
 /**
  * Constants used in testing.
  */
-@SuppressWarnings({ "PMD.CommentSize", "checkstyle:lineLengthChecker" })
 public final class TestConstants {
 
     public static final String INADDR_ANY = "0.0.0.0";
-
-    /**
-     * A test initialization vector used to encrypt {@link #TEST_SINAI_AUTHENTICATED_3DAY}. This is just the value
-     * "0123456789ABCDEF" (see Ruby script below) encoded in hexadecimal.
-     */
-    public static final String TEST_INITIALIZATION_VECTOR = "30313233343536373839414243444546";
-
-    /**
-     * A test cookie generated using the following Ruby code, mocking the relevant part of the Sinai application:
-     * <p>
-     *
-     * <pre>
-     * #!/usr/bin/env ruby
-     *
-     * require "openssl"
-     *
-     * cipher = OpenSSL::Cipher::AES256.new :CBC
-     * cipher.encrypt
-     * cipher.key = "ThisPasswordIsReallyHardToGuess!"
-     * cipher.iv = "0123456789ABCDEF"
-     * puts (cipher.update("Authenticated #{Time.at(0).utc}") + cipher.final).unpack("H*")[0].upcase
-     * </pre>
-     *
-     * @see <a href=
-     *      "https://github.com/UCLALibrary/sinaimanuscripts/blob/44cbbd9bf508c32b742f1617205a679edf77603e/app/controllers/application_controller.rb#L98-L103">How
-     *      the Sinai application encodes cookies</a>
-     */
-    public static final String TEST_SINAI_AUTHENTICATED_3DAY =
-            "5AFF80488740353F8A11B99C7A493D871807521908500772B92E4F8FC919E305A607ADB714B22EF08D2C22FC08C8A6EC";
 
     /*
      * Constant classes have private constructors.

--- a/src/test/java/edu/ucla/library/iiif/auth/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/utils/TestUtils.java
@@ -53,19 +53,18 @@ public final class TestUtils {
                 aLocalDate.format(DateTimeFormatter.ofPattern(AccessCookieServiceImpl.SINAI_COOKIE_DATE_FORMAT));
         final String clearText = String.join(SPACE, clearTextPrefix, clearTextSuffix);
 
-        final Cipher cipher;
-        final SecretKey key;
+        final Cipher cipher = Cipher.getInstance(AccessCookieServiceImpl.CIPHER_TRANSFORMATION);
+        final SecretKey key =
+                new SecretKeySpec(aConfig.getString(Config.SINAI_COOKIE_SECRET_KEY_GENERATION_PASSWORD).getBytes(),
+                        AccessCookieServiceImpl.KEY_ALGORITHM);
+
         final byte[] cipherText;
         final String sinaiAuthenticated3Day;
         final String initializationVector;
 
-        cipher = Cipher.getInstance(AccessCookieServiceImpl.CIPHER_TRANSFORMATION);
-        key = new SecretKeySpec(aConfig.getString(Config.SINAI_COOKIE_SECRET_KEY_GENERATION_PASSWORD).getBytes(),
-                AccessCookieServiceImpl.KEY_ALGORITHM);
         cipher.init(Cipher.ENCRYPT_MODE, key, new SecureRandom());
 
         cipherText = cipher.doFinal(clearText.getBytes());
-
         sinaiAuthenticated3Day = Hex.encodeHexString(cipherText);
         initializationVector = Hex.encodeHexString(cipher.getIV());
 

--- a/src/test/java/edu/ucla/library/iiif/auth/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/utils/TestUtils.java
@@ -1,0 +1,77 @@
+
+package edu.ucla.library.iiif.auth.utils;
+
+import static info.freelibrary.util.Constants.SPACE;
+
+import java.security.SecureRandom;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.codec.binary.Hex;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.iiif.auth.Config;
+import edu.ucla.library.iiif.auth.CookieNames;
+import edu.ucla.library.iiif.auth.MessageCodes;
+import edu.ucla.library.iiif.auth.services.AccessCookieServiceImpl;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.sqlclient.Tuple;
+
+/**
+ * Utilities to assist with testing.
+ */
+@SuppressWarnings({ "PMD.CommentSize", "checkstyle:lineLengthChecker" })
+public final class TestUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestUtils.class, MessageCodes.BUNDLE);
+
+    private TestUtils() {
+    }
+
+    /**
+     * Gets a pair of Sinai cookies by mocking the cookie generation code of the Sinai application.
+     *
+     * @param aConfig The application configuration
+     * @param aLocalDate The date value to put inside the cookie
+     * @return A tuple of size 2 whose first element is a {@link CookieNames#SINAI_CIPHERTEXT} cookie and whose second
+     *         is a {@link CookieNames#SINAI_IV} cookie
+     * @throws Exception If there is an issue generating the cookies
+     * @see <a href=
+     *      "https://github.com/UCLALibrary/sinaimanuscripts/blob/44cbbd9bf508c32b742f1617205a679edf77603e/app/controllers/application_controller.rb#L98-L103">How
+     *      the Sinai application encodes cookies</a>
+     */
+    public static Tuple getMockSinaiCookies(final JsonObject aConfig, final LocalDate aLocalDate) throws Exception {
+        final String clearTextPrefix = aConfig.getString(Config.SINAI_COOKIE_VALID_PREFIX);
+        final String clearTextSuffix =
+                aLocalDate.format(DateTimeFormatter.ofPattern(AccessCookieServiceImpl.SINAI_COOKIE_DATE_FORMAT));
+        final String clearText = String.join(SPACE, clearTextPrefix, clearTextSuffix);
+
+        final Cipher cipher;
+        final SecretKey key;
+        final byte[] cipherText;
+        final String sinaiAuthenticated3Day;
+        final String initializationVector;
+
+        cipher = Cipher.getInstance(AccessCookieServiceImpl.CIPHER_TRANSFORMATION);
+        key = new SecretKeySpec(aConfig.getString(Config.SINAI_COOKIE_SECRET_KEY_GENERATION_PASSWORD).getBytes(),
+                AccessCookieServiceImpl.KEY_ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, key, new SecureRandom());
+
+        cipherText = cipher.doFinal(clearText.getBytes());
+
+        sinaiAuthenticated3Day = Hex.encodeHexString(cipherText);
+        initializationVector = Hex.encodeHexString(cipher.getIV());
+
+        LOGGER.debug(MessageCodes.AUTH_020, CookieNames.SINAI_CIPHERTEXT, sinaiAuthenticated3Day, CookieNames.SINAI_IV,
+                initializationVector, clearText);
+
+        return Tuple.of(sinaiAuthenticated3Day, initializationVector);
+    }
+}


### PR DESCRIPTION
Because the Sinai cookie contains a date value without time or timezone information (e.g., `Authenticated Fri, 04 Mar 2022`), the way I've implemented the validation logic is:

_A cookie is considered "valid" for the remainder of the day on which it is created (less than 24 hours), as well as for the next 3 days (72 hours). After that, it is considered "expired"._

To illustrate, consider that a cookie created at 00:00:00 on a given day would contain the same value as a cookie created at 23:59:59 on the same day. Because of this, there is no way to guarantee that a cookie is considered valid for _exactly_ 72 hours; the best we can do is guarantee either _at least_ 72 hours (the route I've taken) or _at most_ 72 hours.

Due to this limitation, I think we should propose making the value in the cookie more specific (particularly, to use an ISO 8601 format that can be represented as a `ZonedDateTime` using [this method](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZonedDateTime.html#parse(java.lang.CharSequence))); that way, we can guarantee that the cookie is valid for exactly X seconds. I have mentioned this desire as a TODO in a couple places in this PR.

(Of course, all of this assumes that we shouldn't trust the cookie's Max-Age value, since that is modifiable on the client side.)

Also, note the new TestUtils code that replaces the hard-coded cookies that were in TestConstants; it interoperates with AccessCookieServiceImpl, so I made some of the latter's constants public.