### PR TITLE
[SERV-372] Implement relevant access token error conditions

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/auth/AccessTokenError.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/AccessTokenError.java
@@ -1,0 +1,12 @@
+
+package edu.ucla.library.iiif.auth;
+
+/**
+ * Access token error conditions.
+ *
+ * @see <a href="https://iiif.io/api/auth/1.0/#access-token-error-conditions">The semantics of each error</a>
+ */
+@SuppressWarnings("PMD.FieldNamingConventions") // It's easier if the name is the same as the string representation
+public enum AccessTokenError {
+    invalidRequest, missingCredentials, invalidCredentials, invalidOrigin, unavailable
+}

--- a/src/main/java/edu/ucla/library/iiif/auth/Error.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/Error.java
@@ -14,7 +14,7 @@ public enum Error {
 
     /**
      * The failure code if the access cookie service receives a decryption request for an invalid cookie (e.g., one that
-     * has been tampered with or stolen).
+     * is expired, or has been tampered with or stolen).
      */
     INVALID_COOKIE,
 

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AdminAuthenticationErrorHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AdminAuthenticationErrorHandler.java
@@ -45,6 +45,7 @@ public class AdminAuthenticationErrorHandler implements ErrorHandler {
 
             LOGGER.error(MessageCodes.AUTH_006, request.method(), request.absoluteURI(), error.getMessage());
         } else {
+            aContext.next();
             LOGGER.error(MessageCodes.AUTH_010, error.toString());
         }
     }

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/HtmlRenderingErrorHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/HtmlRenderingErrorHandler.java
@@ -45,6 +45,7 @@ public class HtmlRenderingErrorHandler implements ErrorHandler {
 
             LOGGER.error(MessageCodes.AUTH_006, request.method(), request.absoluteURI(), error.getMessage());
         } else {
+            aContext.next();
             LOGGER.error(MessageCodes.AUTH_010, error.toString());
         }
 

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/MissingAccessCookieErrorHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/MissingAccessCookieErrorHandler.java
@@ -1,0 +1,105 @@
+
+package edu.ucla.library.iiif.auth.handlers;
+
+import info.freelibrary.util.HTTP;
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.iiif.auth.AccessTokenError;
+import edu.ucla.library.iiif.auth.CookieNames;
+import edu.ucla.library.iiif.auth.MessageCodes;
+import edu.ucla.library.iiif.auth.Param;
+import edu.ucla.library.iiif.auth.ResponseJsonKeys;
+import edu.ucla.library.iiif.auth.TemplateKeys;
+import edu.ucla.library.iiif.auth.utils.MediaType;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.ErrorHandler;
+import io.vertx.ext.web.templ.handlebars.HandlebarsTemplateEngine;
+import io.vertx.ext.web.validation.ParameterProcessorException;
+
+/**
+ * Handles errors resulting from access token requests that don't include all the required access cookies.
+ */
+public class MissingAccessCookieErrorHandler implements ErrorHandler {
+
+    /**
+     * The handler's logger.
+     */
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(MissingAccessCookieErrorHandler.class, MessageCodes.BUNDLE);
+
+    /**
+     * The template engine for rendering the response.
+     */
+    private final HandlebarsTemplateEngine myHtmlTemplateEngine;
+
+    /**
+     * Creates a handler that exchanges access cookies for access tokens.
+     *
+     * @param aVertx The Vert.x instance
+     */
+    public MissingAccessCookieErrorHandler(final Vertx aVertx) {
+        myHtmlTemplateEngine = HandlebarsTemplateEngine.create(aVertx);
+    }
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final Throwable error = aContext.failure();
+        final HttpServerRequest request = aContext.request();
+
+        if (error instanceof ParameterProcessorException && anyRequiredCookiesMissing(request)) {
+            final String messageID = request.getParam(Param.MESSAGE_ID);
+            final String origin = request.getParam(Param.ORIGIN);
+            final boolean isBrowserClient = messageID != null && origin != null;
+            final MediaType responseContentType = isBrowserClient ? MediaType.TEXT_HTML : MediaType.APPLICATION_JSON;
+            final HttpServerResponse response =
+                    aContext.response().putHeader(HttpHeaders.CONTENT_TYPE, responseContentType.toString());
+            final JsonObject jsonWrapper = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.missingCredentials);
+
+            if (isBrowserClient) {
+                final JsonObject templateData = new JsonObject() //
+                        .put(TemplateKeys.ORIGIN, origin) //
+                        .put(TemplateKeys.ACCESS_TOKEN_OBJECT, jsonWrapper);
+
+                myHtmlTemplateEngine.render(templateData, "templates/token.hbs").onSuccess(html -> {
+                    response.setStatusCode(HTTP.OK).end(html);
+                }).onFailure(aContext::fail);
+            } else {
+                response.setStatusCode(HTTP.BAD_REQUEST).end(jsonWrapper.encodePrettily());
+            }
+
+            LOGGER.error(MessageCodes.AUTH_006, request.method(), request.absoluteURI(), error.getMessage());
+        } else {
+            aContext.next();
+            LOGGER.error(MessageCodes.AUTH_010, error.toString());
+        }
+    }
+
+    /**
+     * Determines whether any required cookies are missing from request (assuming it's an access token request).
+     *
+     * @param aRequest The request
+     * @return true if it's an access token request and is missing cookies, false otherwise
+     */
+    private boolean anyRequiredCookiesMissing(final HttpServerRequest aRequest) {
+        final String requestPath = aRequest.path();
+
+        if (requestPath.startsWith("/token/sinai")) {
+            return aRequest.getCookie(CookieNames.SINAI_CIPHERTEXT) == null ||
+                    aRequest.getCookie(CookieNames.SINAI_IV) == null;
+        }
+
+        if (requestPath.startsWith("/token")) {
+            return aRequest.getCookie(CookieNames.HAUTH) == null;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/SinaiAccessTokenHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/SinaiAccessTokenHandler.java
@@ -33,10 +33,10 @@ public class SinaiAccessTokenHandler extends AbstractAccessTokenHandler {
         final String authCookie = aContext.request().getCookie(CookieNames.SINAI_CIPHERTEXT).getValue();
         final String ivCookie = aContext.request().getCookie(CookieNames.SINAI_IV).getValue();
 
-        return getAccessCookieService().validateSinaiCookie(authCookie, ivCookie).compose(isValid -> {
+        return getAccessCookieService().validateSinaiCookie(authCookie, ivCookie).compose(unused -> {
             final JsonObject unencodedAccessToken =
                     new JsonObject().put(TokenJsonKeys.VERSION, getConfig().getString(Config.HAUTH_VERSION))
-                            .put(TokenJsonKeys.SINAI_AFFILIATE, isValid);
+                            .put(TokenJsonKeys.SINAI_AFFILIATE, true);
             final String accessToken = Base64.getEncoder().encodeToString(unencodedAccessToken.encode().getBytes());
 
             return Future.succeededFuture(accessToken);

--- a/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieService.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieService.java
@@ -3,8 +3,6 @@ package edu.ucla.library.iiif.auth.services;
 
 import java.security.GeneralSecurityException;
 
-import edu.ucla.library.iiif.auth.Config;
-
 import io.vertx.codegen.annotations.ProxyClose;
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.VertxGen;
@@ -83,9 +81,7 @@ public interface AccessCookieService {
      *
      * @param aCipherText An encrypted cookie value returned from {@link Cookie#getValue()}
      * @param anInitializationVector The initialization vector used to encrypt {@code aCipherText}
-     * @return A Future that resolves to whether the decrypted cookie value starts with
-     *         {@link Config#SINAI_COOKIE_VALID_PREFIX}, or fails if the cookie has been tampered with, cannot be
-     *         decrypted, or is otherwise invalid
+     * @return A Future that succeeds if the cookie is valid and not expired, and fails otherwise
      */
-    Future<Boolean> validateSinaiCookie(String aCipherText, String anInitializationVector);
+    Future<Void> validateSinaiCookie(String aCipherText, String anInitializationVector);
 }

--- a/src/main/resources/hauth.yaml
+++ b/src/main/resources/hauth.yaml
@@ -7,6 +7,69 @@ info:
 servers:
 - url: http://github.com/uclalibrary/hauth
 components:
+  parameters:
+    AccessTokenOrigin:
+      name: origin
+      in: query
+      description: The origin of the page, consisting of a protocol, hostname and, optionally, port number
+      schema:
+        type: string
+        format: uri
+        example: https://client.example.com/
+      required: false
+    AccessTokenMessageId:
+      name: messageId
+      in: query
+      description: A string that both prompts the server to respond with a web page instead of JSON, and allows the client to match access token service requests with the messages received
+      schema:
+        type: string
+        example: 1234
+      required: false
+  responses:
+    AccessTokenBrowserClient:
+      description: The access token response for browser-based clients; note that this may represent an error condition
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              accessToken:
+                type: string
+              expiresIn:
+                type: integer
+        text/html:
+          schema:
+            type: string
+            example: '<html><body><script>window.parent.postMessage({"messageId":"1234","accessToken":"TOKEN_HERE","expiresIn": 3600},"https://client.example.com/");</script></body></html>'
+    AccessTokenNonBrowserMissingCredentials:
+      description: The request is missing a required cookie
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                enum: [ missingCredentials ]
+                example: missingCredentials
+    AccessTokenNonBrowserInvalidCredentials:
+      description: The request contains an invalid cookie
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                enum: [ invalidCredentials ]
+                example: invalidCredentials
+    InternalServerError:
+      description: There was an internal server error
+      content:
+        text/plain:
+          schema:
+            type: string
+            example: Internal server error
   securitySchemes:
     Admin:
       type: apiKey
@@ -117,66 +180,17 @@ paths:
           type: string
           example: iiif-access=asrvaaDe43AAqw34QpOoPJR4j5b1; Path=/; HttpOnly
         required: true
-      - in: query
-        name: origin
-        description: The origin of the page, consisting of a protocol, hostname and, optionally, port number
-        schema:
-          type: string
-          format: uri
-          example: https://client.example.com/
-        required: false
-      - in: query
-        name: messageId
-        description: A string that both prompts the server to respond with a web page instead of JSON, and allows the client to match access token service requests with the messages received
-        schema:
-          type: string
-          example: 1234
-        required: false
+      - $ref: '#/components/parameters/AccessTokenOrigin'
+      - $ref: '#/components/parameters/AccessTokenMessageId'
       responses:
         '200':
-          description: The access token response for browser-based clients; note that this may represent an error condition
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  accessToken:
-                    type: string
-                  expiresIn:
-                    type: integer
-            text/html:
-              schema:
-                type: string
-                example: '<html><body><script>window.parent.postMessage({"messageId":"1234","accessToken":"TOKEN_HERE","expiresIn": 3600},"https://client.example.com/");</script></body></html>'
+          $ref: '#/components/responses/AccessTokenBrowserClient'
         '400':
-          description: The request is missing a required cookie
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    enum: [ missingCredentials ]
-                    example: missingCredentials
+          $ref: '#/components/responses/AccessTokenNonBrowserMissingCredentials'
         '401':
-          description: The request contains an invalid cookie
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    enum: [ invalidCredentials ]
-                    example: invalidCredentials
+          $ref: '#/components/responses/AccessTokenNonBrowserInvalidCredentials'
         '500':
-          description: There was an internal server error
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: Internal server error
+          $ref: '#/components/responses/InternalServerError'
   /token/sinai:
     get:
       summary: Get Authentication Token
@@ -195,65 +209,17 @@ paths:
           type: string
           example: initialization_vector=30313233343536373839414243444546
         required: true
-      - in: query
-        name: origin
-        description: The origin of the page, consisting of a protocol, hostname and, optionally, port number
-        schema:
-          type: string
-          example: https://client.example.com/
-        required: false
-      - in: query
-        name: messageId
-        description: A string that both prompts the server to respond with a web page instead of JSON, and allows the client to match access token service requests with the messages received
-        schema:
-          type: string
-          example: 1234
-        required: false
+      - $ref: '#/components/parameters/AccessTokenOrigin'
+      - $ref: '#/components/parameters/AccessTokenMessageId'
       responses:
         '200':
-          description: The access token response for browser-based clients; note that this may represent an error condition
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  accessToken:
-                    type: string
-                  expiresIn:
-                    type: integer
-            text/html:
-              schema:
-                type: string
-                example: '<html><body><script>window.parent.postMessage({"messageId":"1234","accessToken":"TOKEN_HERE","expiresIn": 3600},"https://client.example.com/");</script></body></html>'
+          $ref: '#/components/responses/AccessTokenBrowserClient'
         '400':
-          description: The request is missing a required cookie
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    enum: [ missingCredentials ]
-                    example: missingCredentials
+          $ref: '#/components/responses/AccessTokenNonBrowserMissingCredentials'
         '401':
-          description: The request contains an invalid cookie
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    enum: [ invalidCredentials ]
-                    example: invalidCredentials
+          $ref: '#/components/responses/AccessTokenNonBrowserInvalidCredentials'
         '500':
-          description: There was an internal server error
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: Internal server error
+          $ref: '#/components/responses/InternalServerError'
   /status:
     get:
       summary: Get Application Status

--- a/src/main/resources/hauth.yaml
+++ b/src/main/resources/hauth.yaml
@@ -134,7 +134,7 @@ paths:
         required: false
       responses:
         '200':
-          description: The access token response
+          description: The access token response for browser-based clients; note that this may represent an error condition
           content:
             application/json:
               schema:
@@ -149,7 +149,7 @@ paths:
                 type: string
                 example: '<html><body><script>window.parent.postMessage({"messageId":"1234","accessToken":"TOKEN_HERE","expiresIn": 3600},"https://client.example.com/");</script></body></html>'
         '400':
-          description: The request didn't contain a valid cookie
+          description: The request is missing a required cookie
           content:
             application/json:
               schema:
@@ -157,25 +157,26 @@ paths:
                 properties:
                   error:
                     type: string
-                    enum: [ INVALID_COOKIE ]
-                    example: INVALID_COOKIE
-                  message:
+                    enum: [ missingCredentials ]
+                    example: missingCredentials
+        '401':
+          description: The request contains an invalid cookie
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
                     type: string
-                    example: The request did not contain a valid cookie
+                    enum: [ invalidCredentials ]
+                    example: invalidCredentials
         '500':
           description: There was an internal server error
           content:
-            application/json:
+            text/plain:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    enum: [ CONFIGURATION ]
-                    example: CONFIGURATION
-                  message:
-                    type: string
-                    example: The access cookie decryption service is not configured properly
+                type: string
+                example: Internal server error
   /token/sinai:
     get:
       summary: Get Authentication Token
@@ -210,7 +211,7 @@ paths:
         required: false
       responses:
         '200':
-          description: The access token response
+          description: The access token response for browser-based clients; note that this may represent an error condition
           content:
             application/json:
               schema:
@@ -225,7 +226,7 @@ paths:
                 type: string
                 example: '<html><body><script>window.parent.postMessage({"messageId":"1234","accessToken":"TOKEN_HERE","expiresIn": 3600},"https://client.example.com/");</script></body></html>'
         '400':
-          description: The request didn't contain a valid cookie
+          description: The request is missing a required cookie
           content:
             application/json:
               schema:
@@ -233,23 +234,26 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: INVALID_COOKIE
-                  message:
+                    enum: [ missingCredentials ]
+                    example: missingCredentials
+        '401':
+          description: The request contains an invalid cookie
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
                     type: string
-                    example: The request did not contain a valid cookie
+                    enum: [ invalidCredentials ]
+                    example: invalidCredentials
         '500':
           description: There was an internal server error
           content:
-            application/json:
+            text/plain:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    example: CONFIGURATION
-                  message:
-                    type: string
-                    example: The access cookie decryption service is not configured properly
+                type: string
+                example: Internal server error
   /status:
     get:
       summary: Get Application Status

--- a/src/main/resources/hauth_messages.xml
+++ b/src/main/resources/hauth_messages.xml
@@ -17,7 +17,7 @@
   <entry key="AUTH_009">Expected decryption and decoding of tampered cookie to fail, but it succeeded: {}</entry>
   <entry key="AUTH_010">Unexpected error: {}</entry>
   <entry key="AUTH_011">The request did not contain a valid cookie</entry>
-  <entry key="AUTH_012">The access cookie could not be decoded</entry>
+  <entry key="AUTH_012">The access cookie is expired as of {}</entry>
   <entry key="AUTH_013">Expected the client's IP address ({}) to match what's in the cookie it sent ({})</entry>
   <entry key="AUTH_014">Malformed input data: {}</entry>
   <entry key="AUTH_015">Expected adding items to fail, but it succeeded: {}</entry>

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AbstractAccessTokenHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AbstractAccessTokenHandlerIT.java
@@ -1,0 +1,30 @@
+
+package edu.ucla.library.iiif.auth.handlers;
+
+import java.util.Random;
+
+import info.freelibrary.util.StringUtils;
+
+import edu.ucla.library.iiif.auth.Param;
+
+/**
+ * A base class for access token handler integration tests.
+ */
+public abstract class AbstractAccessTokenHandlerIT extends AbstractHandlerIT {
+
+    /**
+     * Obtains a random unsigned integer by zeroing the sign bit of a random signed integer.
+     */
+    protected final String myMessageID = String.valueOf(new Random().nextInt() & 0x7FFFFFFF);
+
+    /**
+     * The query string to use for token requests by browser clients.
+     */
+    protected final String myGetTokenRequestQuery =
+            StringUtils.format("{}={}&{}={}", Param.MESSAGE_ID, myMessageID, Param.ORIGIN, TEST_ORIGIN);
+
+    /**
+     * The Handlebars template used by the handler for rendering responses to requests by browser clients.
+     */
+    protected final String myTokenResponseTemplate = "src/main/resources/templates/token.hbs";
+}

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessTokenHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessTokenHandlerIT.java
@@ -10,14 +10,13 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
-import java.util.Random;
 
 import org.jsoup.Jsoup;
 import org.junit.jupiter.api.Test;
 
+import edu.ucla.library.iiif.auth.AccessTokenError;
 import edu.ucla.library.iiif.auth.Config;
 import edu.ucla.library.iiif.auth.CookieJsonKeys;
-import edu.ucla.library.iiif.auth.Param;
 import edu.ucla.library.iiif.auth.ResponseJsonKeys;
 import edu.ucla.library.iiif.auth.TemplateKeys;
 import edu.ucla.library.iiif.auth.TokenJsonKeys;
@@ -37,28 +36,12 @@ import io.vertx.junit5.VertxTestContext;
 /**
  * Tests {@link AccessTokenHandler#handle}.
  */
-public final class AccessTokenHandlerIT extends AbstractHandlerIT {
-
-    /**
-     * Obtains a random unsigned integer by zeroing the sign bit of a random signed integer.
-     */
-    private final String myMessageID = String.valueOf(new Random().nextInt() & 0x7FFFFFFF);
-
-    /**
-     * The query string to use for token requests by browser clients.
-     */
-    private final String myGetTokenRequestQuery =
-            StringUtils.format("{}={}&{}={}", Param.MESSAGE_ID, myMessageID, Param.ORIGIN, TEST_ORIGIN);
+public final class AccessTokenHandlerIT extends AbstractAccessTokenHandlerIT {
 
     /**
      * The invalid cookie to test with.
      */
     private final String myInvalidCookieHeader = "iiif-access=invalid";
-
-    /**
-     * The Handlebars template used by the handler for rendering responses to requests by browser clients.
-     */
-    private final String myTokenResponseTemplate = "src/main/resources/templates/token.hbs";
 
     /**
      * The id of the HTML element that contains the client IP address that was put in the cookie.
@@ -180,10 +163,20 @@ public final class AccessTokenHandlerIT extends AbstractHandlerIT {
                 .putHeader(HttpHeaders.COOKIE.toString(), myInvalidCookieHeader);
 
         getToken.send().onSuccess(response -> {
-            assertEquals(HTTP.BAD_REQUEST, response.statusCode());
-            assertEquals(MediaType.TEXT_HTML.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+            final JsonObject expectedError = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.invalidCredentials);
+            final JsonObject templateData = new JsonObject() //
+                    .put(TemplateKeys.ACCESS_TOKEN_OBJECT, expectedError) //
+                    .put(TemplateKeys.ORIGIN, TEST_ORIGIN);
+            final HandlebarsTemplateEngine templateEngine = HandlebarsTemplateEngine.create(aVertx);
 
-            aContext.completeNow();
+            templateEngine.render(templateData, myTokenResponseTemplate).onSuccess(expected -> {
+                assertEquals(HTTP.OK, response.statusCode());
+                assertEquals(MediaType.TEXT_HTML.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+                assertEquals(expected, response.bodyAsBuffer());
+
+                aContext.completeNow();
+            }).onFailure(aContext::failNow);
         }).onFailure(aContext::failNow);
     }
 
@@ -200,8 +193,64 @@ public final class AccessTokenHandlerIT extends AbstractHandlerIT {
                 .putHeader(HttpHeaders.COOKIE.toString(), myInvalidCookieHeader);
 
         getToken.send().onSuccess(response -> {
+            final JsonObject expectedError = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.invalidCredentials);
+
+            assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+            assertEquals(expectedError, response.bodyAsJsonObject());
+
+            aContext.completeNow();
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that a browser client must provide an access cookie to obtain an access token.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testGetTokenBrowserMissingCookie(final Vertx aVertx, final VertxTestContext aContext) {
+        final String getTokenRequestURI = StringUtils.format(GET_TOKEN_PATH, myGetTokenRequestQuery);
+        final HttpRequest<?> getToken = myWebClient.get(myPort, TestConstants.INADDR_ANY, getTokenRequestURI);
+
+        getToken.send().onSuccess(response -> {
+            final JsonObject expectedError = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.missingCredentials);
+            final JsonObject templateData = new JsonObject() //
+                    .put(TemplateKeys.ACCESS_TOKEN_OBJECT, expectedError) //
+                    .put(TemplateKeys.ORIGIN, TEST_ORIGIN);
+            final HandlebarsTemplateEngine templateEngine = HandlebarsTemplateEngine.create(aVertx);
+
+            templateEngine.render(templateData, myTokenResponseTemplate).onSuccess(expected -> {
+                assertEquals(HTTP.OK, response.statusCode());
+                assertEquals(MediaType.TEXT_HTML.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+                assertEquals(expected, response.bodyAsBuffer());
+
+                aContext.completeNow();
+            }).onFailure(aContext::failNow);
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that a non-browser client must provide an access cookie to obtain an access token.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testGetTokenNonBrowserMissingCookie(final Vertx aVertx, final VertxTestContext aContext) {
+        final String requestURI = StringUtils.format(GET_TOKEN_PATH, EMPTY);
+        final HttpRequest<?> getToken = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestURI);
+
+        getToken.send().onSuccess(response -> {
+            final JsonObject expectedError = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.missingCredentials);
+
             assertEquals(HTTP.BAD_REQUEST, response.statusCode());
             assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+            assertEquals(expectedError, response.bodyAsJsonObject());
 
             aContext.completeNow();
         }).onFailure(aContext::failNow);

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/SinaiAccessTokenHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/SinaiAccessTokenHandlerIT.java
@@ -7,13 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Base64;
 import java.util.Optional;
-import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
+import edu.ucla.library.iiif.auth.AccessTokenError;
 import edu.ucla.library.iiif.auth.Config;
 import edu.ucla.library.iiif.auth.CookieNames;
-import edu.ucla.library.iiif.auth.Param;
 import edu.ucla.library.iiif.auth.ResponseJsonKeys;
 import edu.ucla.library.iiif.auth.TemplateKeys;
 import edu.ucla.library.iiif.auth.TokenJsonKeys;
@@ -34,18 +33,7 @@ import io.vertx.sqlclient.Tuple;
 /**
  * Tests {@link SinaiAccessTokenHandler#handle}.
  */
-public final class SinaiAccessTokenHandlerIT extends AbstractHandlerIT {
-
-    /**
-     * Obtains a random unsigned integer by zeroing the sign bit of a random signed integer.
-     */
-    private final String myMessageID = String.valueOf(new Random().nextInt() & 0x7FFFFFFF);
-
-    /**
-     * The query string to use for token requests by browser clients.
-     */
-    private final String myGetTokenRequestQuery =
-            StringUtils.format("{}={}&{}={}", Param.MESSAGE_ID, myMessageID, Param.ORIGIN, TEST_ORIGIN);
+public final class SinaiAccessTokenHandlerIT extends AbstractAccessTokenHandlerIT {
 
     /**
      * The cookie header template to use in Sinai access token requests.
@@ -59,11 +47,6 @@ public final class SinaiAccessTokenHandlerIT extends AbstractHandlerIT {
             StringUtils.format(mySinaiCookieHeaderTemplate, CookieNames.SINAI_CIPHERTEXT,
                     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     CookieNames.SINAI_IV, "30313233343536373839414243444546");
-
-    /**
-     * The Handlebars template used by the handler for rendering responses to requests by browser clients.
-     */
-    private final String myTokenResponseTemplate = "src/main/resources/templates/token.hbs";
 
     /**
      * Tests that a browser client can use a valid access cookie to obtain an access token.
@@ -140,7 +123,59 @@ public final class SinaiAccessTokenHandlerIT extends AbstractHandlerIT {
         }).onFailure(aContext::failNow);
     }
 
-    // TODO: add tests for expired cookies
+    /**
+     * Tests that a browser client can't use an expired access cookie to obtain an access token.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testGetTokenBrowserExpiredCookie(final Vertx aVertx, final VertxTestContext aContext) {
+        final String requestURI = StringUtils.format(GET_TOKEN_SINAI_PATH, myGetTokenRequestQuery);
+        final HttpRequest<?> getToken = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestURI)
+                .putHeader(HttpHeaders.COOKIE.toString(), getSinaiCookieHeader(myMockSinaiCookiesExpired));
+
+        getToken.send().onSuccess(response -> {
+            final JsonObject expectedError = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.invalidCredentials);
+            final JsonObject templateData = new JsonObject() //
+                    .put(TemplateKeys.ACCESS_TOKEN_OBJECT, expectedError) //
+                    .put(TemplateKeys.ORIGIN, TEST_ORIGIN);
+            final HandlebarsTemplateEngine templateEngine = HandlebarsTemplateEngine.create(aVertx);
+
+            templateEngine.render(templateData, myTokenResponseTemplate).onSuccess(expected -> {
+                assertEquals(HTTP.OK, response.statusCode());
+                assertEquals(MediaType.TEXT_HTML.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+                assertEquals(expected, response.bodyAsBuffer());
+
+                aContext.completeNow();
+            }).onFailure(aContext::failNow);
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that a non-browser client can't use an expired access cookie to obtain an access token.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testGetTokenNonBrowserExpiredCookie(final Vertx aVertx, final VertxTestContext aContext) {
+        final String requestURI = StringUtils.format(GET_TOKEN_SINAI_PATH, EMPTY);
+        final HttpRequest<?> getToken = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestURI)
+                .putHeader(HttpHeaders.COOKIE.toString(), getSinaiCookieHeader(myMockSinaiCookiesExpired));
+
+        getToken.send().onSuccess(response -> {
+            final JsonObject expectedError = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.invalidCredentials);
+
+            assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+            assertEquals(expectedError, response.bodyAsJsonObject());
+
+            aContext.completeNow();
+        }).onFailure(aContext::failNow);
+    }
 
     /**
      * Tests that a browser client can't use an invalid access cookie to obtain an access token.
@@ -155,10 +190,20 @@ public final class SinaiAccessTokenHandlerIT extends AbstractHandlerIT {
                 .putHeader(HttpHeaders.COOKIE.toString(), myInvalidCookieHeader);
 
         getToken.send().onSuccess(response -> {
-            assertEquals(HTTP.BAD_REQUEST, response.statusCode());
-            assertEquals(MediaType.TEXT_HTML.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+            final JsonObject expectedError = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.invalidCredentials);
+            final JsonObject templateData = new JsonObject() //
+                    .put(TemplateKeys.ACCESS_TOKEN_OBJECT, expectedError) //
+                    .put(TemplateKeys.ORIGIN, TEST_ORIGIN);
+            final HandlebarsTemplateEngine templateEngine = HandlebarsTemplateEngine.create(aVertx);
 
-            aContext.completeNow();
+            templateEngine.render(templateData, myTokenResponseTemplate).onSuccess(expected -> {
+                assertEquals(HTTP.OK, response.statusCode());
+                assertEquals(MediaType.TEXT_HTML.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+                assertEquals(expected, response.bodyAsBuffer());
+
+                aContext.completeNow();
+            }).onFailure(aContext::failNow);
         }).onFailure(aContext::failNow);
     }
 
@@ -175,8 +220,64 @@ public final class SinaiAccessTokenHandlerIT extends AbstractHandlerIT {
                 .putHeader(HttpHeaders.COOKIE.toString(), myInvalidCookieHeader);
 
         getToken.send().onSuccess(response -> {
+            final JsonObject expectedError = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.invalidCredentials);
+
+            assertEquals(HTTP.UNAUTHORIZED, response.statusCode());
+            assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+            assertEquals(expectedError, response.bodyAsJsonObject());
+
+            aContext.completeNow();
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that a browser client must provide an access cookie to obtain an access token.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testGetTokenBrowserMissingCookie(final Vertx aVertx, final VertxTestContext aContext) {
+        final String getTokenRequestURI = StringUtils.format(GET_TOKEN_SINAI_PATH, myGetTokenRequestQuery);
+        final HttpRequest<?> getToken = myWebClient.get(myPort, TestConstants.INADDR_ANY, getTokenRequestURI);
+
+        getToken.send().onSuccess(response -> {
+            final JsonObject expectedError = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.missingCredentials);
+            final JsonObject templateData = new JsonObject() //
+                    .put(TemplateKeys.ACCESS_TOKEN_OBJECT, expectedError) //
+                    .put(TemplateKeys.ORIGIN, TEST_ORIGIN);
+            final HandlebarsTemplateEngine templateEngine = HandlebarsTemplateEngine.create(aVertx);
+
+            templateEngine.render(templateData, myTokenResponseTemplate).onSuccess(expected -> {
+                assertEquals(HTTP.OK, response.statusCode());
+                assertEquals(MediaType.TEXT_HTML.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+                assertEquals(expected, response.bodyAsBuffer());
+
+                aContext.completeNow();
+            }).onFailure(aContext::failNow);
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that a non-browser client must provide an access cookie to obtain an access token.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testGetTokenNonBrowserMissingCookie(final Vertx aVertx, final VertxTestContext aContext) {
+        final String requestURI = StringUtils.format(GET_TOKEN_SINAI_PATH, EMPTY);
+        final HttpRequest<?> getToken = myWebClient.get(myPort, TestConstants.INADDR_ANY, requestURI);
+
+        getToken.send().onSuccess(response -> {
+            final JsonObject expectedError = new JsonObject() //
+                    .put(ResponseJsonKeys.ERROR, AccessTokenError.missingCredentials);
+
             assertEquals(HTTP.BAD_REQUEST, response.statusCode());
             assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+            assertEquals(expectedError, response.bodyAsJsonObject());
 
             aContext.completeNow();
         }).onFailure(aContext::failNow);

--- a/src/test/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceTest.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceTest.java
@@ -2,7 +2,6 @@
 package edu.ucla.library.iiif.auth.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.GeneralSecurityException;
@@ -219,18 +218,11 @@ public class AccessCookieServiceTest extends AbstractServiceTest {
      */
     @Test
     public final void testValidateSinaiCookie(final Vertx aVertx, final VertxTestContext aContext) {
-        final Future<Boolean> validateCookieFresh = validateSinaiCookieTuple(myMockSinaiCookiesFresh);
-        final Future<Boolean> validateCookie3DaysOld = validateSinaiCookieTuple(myMockSinaiCookies3DaysOld);
+        final Future<Void> validateCookieFresh = validateSinaiCookieTuple(myMockSinaiCookiesFresh);
+        final Future<Void> validateCookie3DaysOld = validateSinaiCookieTuple(myMockSinaiCookies3DaysOld);
 
         CompositeFuture.all(validateCookieFresh, validateCookie3DaysOld).onSuccess(result -> {
-            try {
-                assertTrue(result.<Boolean>resultAt(0));
-                assertTrue(result.<Boolean>resultAt(1));
-
-                aContext.completeNow();
-            } catch (final AssertionError details) {
-                aContext.failNow(details);
-            }
+            aContext.completeNow();
         }).onFailure(aContext::failNow);
     }
 
@@ -242,17 +234,13 @@ public class AccessCookieServiceTest extends AbstractServiceTest {
      */
     @Test
     public final void testInvalidateExpiredSinaiCookie(final Vertx aVertx, final VertxTestContext aContext) {
-        final Future<Boolean> validateCookie4DaysOld = validateSinaiCookieTuple(myMockSinaiCookies4DaysOld);
+        final Future<Void> validateCookie4DaysOld = validateSinaiCookieTuple(myMockSinaiCookies4DaysOld);
 
-        validateCookie4DaysOld.onSuccess(result -> {
-            try {
-                assertFalse(result);
-
-                aContext.completeNow();
-            } catch (final AssertionError details) {
-                aContext.failNow(LOGGER.getMessage(MessageCodes.AUTH_019));
-            }
-        }).onFailure(aContext::failNow);
+        validateCookie4DaysOld.onFailure(result -> {
+            aContext.completeNow();
+        }).onSuccess(result -> {
+            aContext.failNow(LOGGER.getMessage(MessageCodes.AUTH_019));
+        });
     }
 
     protected Logger getLogger() {
@@ -266,7 +254,7 @@ public class AccessCookieServiceTest extends AbstractServiceTest {
      *        {@link TestUtils#getMockSinaiCookies(JsonObject, LocalDate)}
      * @return The result of validating the cookies
      */
-    private Future<Boolean> validateSinaiCookieTuple(final Tuple aCookieTuple) {
+    private Future<Void> validateSinaiCookieTuple(final Tuple aCookieTuple) {
         return myServiceProxy.validateSinaiCookie(aCookieTuple.getString(0), aCookieTuple.getString(1));
     }
 }


### PR DESCRIPTION
See commit message for why only two of the error conditions are implemented.

Other notes:

* AccessCookieService.validateSinaiCookie now simply returns a Future\<Void\> instead of Future\<Boolean\> so that requests with expired cookies can use the same error handling code as requests with otherwise malformed cookies (by triggering a ServiceException if the cookies are expired)
  * i.e., requests with expired cookies now result in a failed Future that wraps a ServiceException, so that we can get [here](https://github.com/UCLALibrary/hauth/pull/34/files#diff-4c002bd208b508d6bb3a4507fcf9a194c586e65cfbe24d5c08b0e6a35e050cfbR137)
* ErrorHandlers now call RoutingContext::next in case there is another error handler that is better suited to handle a given error
* See new comment in MainVerticle on MissingAccessCookieErrorHandler
* AbstractAccessTokenHandlerIT de-duplicates some code