### PR TITLE
[SERV-390] Allow access cookie service window to close without user interaction 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ These are a work in progress. Randomized ports and passwords are created on the 
 | ENV Property | Default Value | Required |
 | --- | --- | --- |
 | ACCESS_COOKIE_WINDOW_CLOSE_DELAY | XXX | No
-| ACCESS_TOKEN_EXPIRES_IN | 3600 | No |
-| API_KEY | XXXX | Yes |
+| ACCESS_TOKEN_EXPIRES_IN | XXX | No |
+| API_KEY | XXX | Yes |
 | API_SPEC | hauth.yaml | No |
 | CAMPUS_NETWORK_SUBNETS | XXX | Yes |
 | DB_CACHE_HOST | localhost | No |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ These are a work in progress. Randomized ports and passwords are created on the 
 
 | ENV Property | Default Value | Required |
 | --- | --- | --- |
+| ACCESS_COOKIE_WINDOW_CLOSE_DELAY | XXX | No
 | ACCESS_TOKEN_EXPIRES_IN | 3600 | No |
 | API_KEY | XXXX | Yes |
 | API_SPEC | hauth.yaml | No |

--- a/pom.xml
+++ b/pom.xml
@@ -736,6 +736,7 @@
                 <hauth>
                   <run>
                     <env>
+                      <ACCESS_COOKIE_WINDOW_CLOSE_DELAY>0</ACCESS_COOKIE_WINDOW_CLOSE_DELAY>
                       <ACCESS_TOKEN_EXPIRES_IN>1800</ACCESS_TOKEN_EXPIRES_IN>
                     </env>
                   </run>
@@ -747,6 +748,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <environmentVariables>
+                <ACCESS_COOKIE_WINDOW_CLOSE_DELAY>0</ACCESS_COOKIE_WINDOW_CLOSE_DELAY>
                 <ACCESS_TOKEN_EXPIRES_IN>1800</ACCESS_TOKEN_EXPIRES_IN>
               </environmentVariables>
             </configuration>

--- a/src/main/java/edu/ucla/library/iiif/auth/Config.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/Config.java
@@ -23,6 +23,14 @@ public final class Config {
     public static final String HTTP_HOST = "HTTP_HOST";
 
     /**
+     * The optional ENV property for the number of seconds after which the pop-up window that is presented to users
+     * after their client has called the access cookie service should close.
+     * <p>
+     * If unset, the window must be closed with user interaction.
+     */
+    public static final String ACCESS_COOKIE_WINDOW_CLOSE_DELAY = "ACCESS_COOKIE_WINDOW_CLOSE_DELAY";
+
+    /**
      * The optional ENV property for the number of seconds after which an access token will cease to be valid.
      */
     public static final String ACCESS_TOKEN_EXPIRES_IN = "ACCESS_TOKEN_EXPIRES_IN";

--- a/src/main/java/edu/ucla/library/iiif/auth/TemplateKeys.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/TemplateKeys.java
@@ -27,6 +27,11 @@ public final class TemplateKeys {
     public static final String DEGRADED_ALLOWED = "degradedAllowed";
 
     /**
+     * The window close delay key.
+     */
+    public static final String WINDOW_CLOSE_DELAY = "windowCloseDelay";
+
+    /**
      * The origin key.
      */
     public static final String ORIGIN = "origin";

--- a/src/main/resources/templates/cookie.hbs
+++ b/src/main/resources/templates/cookie.hbs
@@ -47,12 +47,17 @@
     {{/unless}}
 
     <p>
-        <em>To continue, please close this tab (or window).</em>
+        {{#neq windowCloseDelay null}}
+        <em>This window will automatically close in <span id="countdown">{{windowCloseDelay}}</span> seconds.</em>
+        {{else}}
+        <em>To continue, please close this window.</em>
+        {{/neq}}
     </p>
     <hr>
     <p>
         <span id="version" style="font-style: italic;">Hauth v{{version}}</span>
     </p>
+
     <style>
         em {
             font-style: normal;
@@ -65,4 +70,22 @@
             color: red;
         }
     </style>
+
+    {{#neq windowCloseDelay null}}
+    <script>
+        function countdown(delay) {
+            document.getElementById("countdown").innerText = delay
+
+            if (delay === 0) {
+                window.close()
+            } else {
+                setTimeout(function() {
+                    countdown(delay - 1)
+                }, 1000)
+            }
+        }
+
+        countdown({{windowCloseDelay}})
+    </script>
+    {{/neq}}
 </body>

--- a/src/main/resources/templates/cookie.hbs
+++ b/src/main/resources/templates/cookie.hbs
@@ -46,32 +46,10 @@
     </p>
     {{/unless}}
 
-    <p>
-        {{#neq windowCloseDelay null}}
-        <em>This window will automatically close in <span id="countdown">{{windowCloseDelay}}</span> seconds.</em>
-        {{else}}
-        <em>To continue, please close this window.</em>
-        {{/neq}}
-    </p>
-    <hr>
-    <p>
-        <span id="version" style="font-style: italic;">Hauth v{{version}}</span>
-    </p>
-
-    <style>
-        em {
-            font-style: normal;
-            font-weight: bold;
-        }
-        .green {
-            color: green;
-        }
-        .red {
-            color: red;
-        }
-    </style>
-
     {{#neq windowCloseDelay null}}
+    <p>
+        <em>This window will automatically close in <span id="countdown">{{windowCloseDelay}}</span> seconds.</em>
+    </p>
     <script>
         function countdown(delay) {
             document.getElementById("countdown").innerText = delay
@@ -87,5 +65,26 @@
 
         countdown({{windowCloseDelay}})
     </script>
+    {{else}}
+    <p>
+        <em>To continue, please close this window.</em>
+    </p>
     {{/neq}}
+
+    <hr>
+    <p>
+        <span id="version" style="font-style: italic;">Hauth v{{version}}</span>
+    </p>
+    <style>
+        em {
+            font-style: normal;
+            font-weight: bold;
+        }
+        .green {
+            color: green;
+        }
+        .red {
+            color: red;
+        }
+    </style>
 </body>


### PR DESCRIPTION
Summary:
* It is now possible to make the access cookie service pop-up window disappear without user interaction, via ACCESS_COOKIE_WINDOW_CLOSE_DELAY (set to `0` to close immediately)
  * I have successfully tested this feature with Mirador 3
* Some misinformation in the README about the application config has been corrected