### PR TITLE
Remove reference to invisible class to fix Javadoc generation

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseService.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseService.java
@@ -72,7 +72,7 @@ public interface DatabaseService {
     /**
      * Sets the given items.
      *
-     * @param aItems An array of objects that can be deserialized to a list of {@link DatabaseServiceImpl.Item}
+     * @param aItems An array of objects that conforms to the request body schema of the "postItems" OpenAPI operation
      * @return A Future that resolves once the items have been set
      */
     Future<Void> setItems(JsonArray aItems);


### PR DESCRIPTION
One may pull this branch and run
```
mvn compile javadoc:javadoc
```
to confirm that it runs to success with no warnings.

**Edit:** forgot compile step