### PR TITLE
[SERV-467] Enable configuration of access cookie domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This will spin up Hauth locally, along with the Redis, PostgreSQL, and Cantaloup
 
 | Name | Default Value | Required |
 | --- | --- | --- |
+| ACCESS_COOKIE_DOMAIN | XXX | No
 | ACCESS_COOKIE_WINDOW_CLOSE_DELAY | XXX | No
 | ACCESS_TOKEN_EXPIRES_IN | XXX | No |
 | API_KEY | XXX | Yes |

--- a/pom.xml
+++ b/pom.xml
@@ -806,6 +806,7 @@
                   <run>
                     <env>
                       <ACCESS_COOKIE_WINDOW_CLOSE_DELAY>0</ACCESS_COOKIE_WINDOW_CLOSE_DELAY>
+                      <ACCESS_COOKIE_DOMAIN>example.com</ACCESS_COOKIE_DOMAIN>
                       <ACCESS_TOKEN_EXPIRES_IN>1800</ACCESS_TOKEN_EXPIRES_IN>
                     </env>
                   </run>
@@ -818,6 +819,7 @@
             <configuration>
               <environmentVariables>
                 <ACCESS_COOKIE_WINDOW_CLOSE_DELAY>0</ACCESS_COOKIE_WINDOW_CLOSE_DELAY>
+                <ACCESS_COOKIE_DOMAIN>example.com</ACCESS_COOKIE_DOMAIN>
                 <ACCESS_TOKEN_EXPIRES_IN>1800</ACCESS_TOKEN_EXPIRES_IN>
               </environmentVariables>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -806,6 +806,7 @@
                   <run>
                     <env>
                       <ACCESS_COOKIE_WINDOW_CLOSE_DELAY>0</ACCESS_COOKIE_WINDOW_CLOSE_DELAY>
+                      <!--  It is recommended to use the most specific domain that Hauth shares with all of the content domains that it provides authentication services for -->
                       <ACCESS_COOKIE_DOMAIN>example.com</ACCESS_COOKIE_DOMAIN>
                       <ACCESS_TOKEN_EXPIRES_IN>1800</ACCESS_TOKEN_EXPIRES_IN>
                     </env>

--- a/src/main/java/edu/ucla/library/iiif/auth/Config.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/Config.java
@@ -30,6 +30,15 @@ public final class Config {
     public static final String ACCESS_COOKIE_WINDOW_CLOSE_DELAY = "ACCESS_COOKIE_WINDOW_CLOSE_DELAY";
 
     /**
+     * The optional ENV property for the host domain to which the access cookie will be sent. It is recommended to use
+     * the most specific domain that Hauth shares with all of the content domains that it provides authentication
+     * services for.
+     * <p>
+     * If unset, the access cookie will be sent to whatever domain Hauth itself is hosted at.
+     */
+    public static final String ACCESS_COOKIE_DOMAIN = "ACCESS_COOKIE_DOMAIN";
+
+    /**
      * The optional ENV property for the number of seconds after which an access token will cease to be valid.
      */
     public static final String ACCESS_TOKEN_EXPIRES_IN = "ACCESS_TOKEN_EXPIRES_IN";

--- a/src/main/java/edu/ucla/library/iiif/auth/Config.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/Config.java
@@ -30,9 +30,7 @@ public final class Config {
     public static final String ACCESS_COOKIE_WINDOW_CLOSE_DELAY = "ACCESS_COOKIE_WINDOW_CLOSE_DELAY";
 
     /**
-     * The optional ENV property for the host domain to which the access cookie will be sent. It is recommended to use
-     * the most specific domain that Hauth shares with all of the content domains that it provides authentication
-     * services for.
+     * The optional ENV property for the host domain to which the access cookie will be sent.
      * <p>
      * If unset, the access cookie will be sent to whatever domain Hauth itself is hosted at.
      */

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandler.java
@@ -76,6 +76,11 @@ public class AccessCookieHandler implements Handler<RoutingContext> {
     private final AccessCookieService myAccessCookieService;
 
     /**
+     * See {@link Config#ACCESS_COOKIE_DOMAIN}.
+     */
+    private final Optional<String> myCookieDomain;
+
+    /**
      * See {@link Config#ACCESS_COOKIE_WINDOW_CLOSE_DELAY}.
      */
     private final Optional<Integer> myWindowCloseDelay;
@@ -93,6 +98,7 @@ public class AccessCookieHandler implements Handler<RoutingContext> {
         myCampusNetworkSubnets = new Cidr4Trie<>();
         myAccessCookieService = AccessCookieService.createProxy(aVertx);
         myWindowCloseDelay = Optional.ofNullable(aConfig.getInteger(Config.ACCESS_COOKIE_WINDOW_CLOSE_DELAY));
+        myCookieDomain = Optional.ofNullable(aConfig.getString(Config.ACCESS_COOKIE_DOMAIN));
 
         // Register the neq helper
         ((Handlebars) myHtmlTemplateEngine.unwrap()).registerHelpers(ConditionalHelpers.class);
@@ -146,6 +152,7 @@ public class AccessCookieHandler implements Handler<RoutingContext> {
                         templateData.put(TemplateKeys.WINDOW_CLOSE_DELAY, delay);
                     }
                 });
+                myCookieDomain.ifPresent(cookie::setDomain);
 
                 response.addCookie(cookie);
 

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandlerIT.java
@@ -2,6 +2,8 @@
 package edu.ucla.library.iiif.auth.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -15,6 +17,7 @@ import info.freelibrary.util.Constants;
 import info.freelibrary.util.HTTP;
 import info.freelibrary.util.StringUtils;
 
+import edu.ucla.library.iiif.auth.Config;
 import edu.ucla.library.iiif.auth.utils.MediaType;
 
 import io.vertx.core.Vertx;
@@ -41,6 +44,7 @@ public final class AccessCookieHandlerIT extends AbstractHandlerIT {
         final String requestURI =
                 StringUtils.format(GET_COOKIE_PATH, URLEncoder.encode(TEST_ORIGIN, StandardCharsets.UTF_8));
         final HttpRequest<?> getCookie = myWebClient.get(myPort, Constants.INADDR_ANY, requestURI);
+        final String explicitCookieDomain = myConfig.getString(Config.ACCESS_COOKIE_DOMAIN);
 
         if (aReverseProxyDeployment) {
             getCookie.putHeader(X_FORWARDED_FOR, FORWARDED_IP_ADDRESSES);
@@ -48,6 +52,8 @@ public final class AccessCookieHandlerIT extends AbstractHandlerIT {
 
         getCookie.send().onSuccess(response -> {
             aContext.verify(() -> {
+                final String cookie;
+
                 assertEquals(HTTP.OK, response.statusCode());
                 assertEquals(MediaType.TEXT_HTML.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
                 assertEquals(1, response.cookies().size());
@@ -55,6 +61,14 @@ public final class AccessCookieHandlerIT extends AbstractHandlerIT {
                 if (aReverseProxyDeployment) {
                     assertEquals(FORWARDED_CLIENT_IP,
                             Jsoup.parse(response.bodyAsString()).getElementById("client-ip-address").text());
+                }
+
+                cookie = response.cookies().get(0);
+
+                if (explicitCookieDomain != null) {
+                    assertTrue(cookie.contains(StringUtils.format("Domain={}", explicitCookieDomain)));
+                } else {
+                    assertFalse(cookie.contains("Domain="));
                 }
 
                 aContext.completeNow();

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessTokenHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessTokenHandlerIT.java
@@ -40,6 +40,8 @@ import io.vertx.junit5.VertxTestContext;
  */
 public final class AccessTokenHandlerIT extends AbstractAccessTokenHandlerIT {
 
+    private static final String SEMICOLON = ";";
+
     /**
      * The invalid cookie to test with.
      */
@@ -71,7 +73,7 @@ public final class AccessTokenHandlerIT extends AbstractAccessTokenHandlerIT {
 
         getCookie.send().compose(result -> {
             final String cookieHeader = result.cookies().get(0);
-            final String cookieValue = cookieHeader.split(EQUALS)[1];
+            final String cookieValue = cookieHeader.split(SEMICOLON)[0].split(EQUALS)[1];
             final String clientIpAddress;
 
             if (aReverseProxyDeployment) {
@@ -146,7 +148,7 @@ public final class AccessTokenHandlerIT extends AbstractAccessTokenHandlerIT {
 
         getCookie.send().compose(result -> {
             final String cookieHeader = result.cookies().get(0);
-            final String cookieValue = cookieHeader.split(EQUALS)[1];
+            final String cookieValue = cookieHeader.split(SEMICOLON)[0].split(EQUALS)[1];
             final String clientIpAddress;
 
             if (aReverseProxyDeployment) {


### PR DESCRIPTION
In our case, we would use:
```
ACCESS_COOKIE_DOMAIN=iiif.library.ucla.edu
```
