### PR TITLE
[SERV-575] Prevent Chrome from filtering out access cookie

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <vertx.version>4.3.3</vertx.version>
 
     <!-- Security update overrides -->
-    <snakeyaml.version>1.31</snakeyaml.version>
+    <snakeyaml.version>1.32</snakeyaml.version>
 
     <!-- Build plugin versions -->
     <clean.plugin.version>3.1.0</clean.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
     <cantaloupe.version>5.0.4-1</cantaloupe.version>
     <auth.delegate.version>0.0.1-SNAPSHOT</auth.delegate.version>
     <jsoup.version>1.14.3</jsoup.version>
-    <netty.codec.version>4.1.82.Final</netty.codec.version>
 
     <!-- Fluency logback dependencies -->
     <fluency.core.version>2.6.4</fluency.core.version>
@@ -231,12 +230,6 @@
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
       <version>${jsoup.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec</artifactId>
-      <version>${netty.codec.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,7 @@
     <freelib.utils.version>3.2.0</freelib.utils.version>
     <cidr.ip.version>1.0.1</cidr.ip.version>
     <commons.codec.version>1.15</commons.codec.version>
-    <vertx.version>4.3.3</vertx.version>
-
-    <!-- Security update overrides -->
-    <snakeyaml.version>1.32</snakeyaml.version>
+    <vertx.version>4.3.4</vertx.version>
 
     <!-- Build plugin versions -->
     <clean.plugin.version>3.1.0</clean.plugin.version>
@@ -188,13 +185,6 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>${commons.codec.version}</version>
-    </dependency>
-
-    <!-- Security update overrides -->
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>${snakeyaml.version}</version>
     </dependency>
 
     <!-- A Vert.x plug-in for more flexible configuration control -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <cantaloupe.version>5.0.4-1</cantaloupe.version>
     <auth.delegate.version>0.0.1-SNAPSHOT</auth.delegate.version>
     <jsoup.version>1.14.3</jsoup.version>
+    <netty.codec.version>4.1.82.Final</netty.codec.version>
 
     <!-- Fluency logback dependencies -->
     <fluency.core.version>2.6.4</fluency.core.version>
@@ -231,6 +232,11 @@
       <artifactId>jsoup</artifactId>
       <version>${jsoup.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec</artifactId>
+      <version>${netty.codec.version}</version>
     </dependency>
 
     <!-- Fluency logback dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
       <version>${netty.codec.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Fluency logback dependencies -->

--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandler.java
@@ -31,6 +31,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.Cookie;
+import io.vertx.core.http.CookieSameSite;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -140,7 +141,8 @@ public class AccessCookieHandler implements Handler<RoutingContext> {
                     isOnCampusNetwork, isDegradedAllowed);
 
             return cookieGeneration.compose(cookieValue -> {
-                final Cookie cookie = Cookie.cookie(CookieNames.HAUTH, cookieValue);
+                final Cookie cookie =
+                        Cookie.cookie(CookieNames.HAUTH, cookieValue).setSameSite(CookieSameSite.NONE).setSecure(true);
 
                 // Along with the origin, pass all the cookie data to the HTML template
                 final JsonObject templateData = new JsonObject().put(TemplateKeys.ORIGIN, origin)

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandlerIT.java
@@ -70,6 +70,8 @@ public final class AccessCookieHandlerIT extends AbstractHandlerIT {
                 } else {
                     assertFalse(cookie.contains("Domain="));
                 }
+                assertTrue(cookie.contains("SameSite=None"));
+                assertTrue(cookie.contains("Secure"));
 
                 aContext.completeNow();
             });


### PR DESCRIPTION
Apparently, Chrome requires that [cookies with the SameSite=None attribute must also have Secure](https://datatracker.ietf.org/doc/html/draft-west-cookie-incrementalism-00#section-3.2).