### PR TITLE
Allow requests from all client origins to obtain access cookie

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <freelib.utils.version>3.3.0</freelib.utils.version>
     <cidr.ip.version>1.0.1</cidr.ip.version>
     <commons.codec.version>1.15</commons.codec.version>
-    <vertx.version>4.3.8</vertx.version>
+    <vertx.version>4.4.2</vertx.version>
 
     <!-- Build plugin versions -->
     <clean.plugin.version>3.1.0</clean.plugin.version>

--- a/src/main/java/edu/ucla/library/iiif/auth/CookieJsonKeys.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/CookieJsonKeys.java
@@ -19,8 +19,7 @@ package edu.ucla.library.iiif.auth;
  * <pre>
  * {
  *   "clientIpAddress": "127.0.0.1",
- *   "campusNetwork": false,
- *   "degradedAllowed": true
+ *   "campusNetwork": false
  * }
  * </pre>
  */
@@ -50,11 +49,6 @@ public final class CookieJsonKeys {
      * The JSON key for whether the client IP address is on the campus network.
      */
     public static final String CAMPUS_NETWORK = "campusNetwork";
-
-    /**
-     * The JSON key for whether degraded content is available at the origin for which the cookie applies.
-     */
-    public static final String DEGRADED_ALLOWED = "degradedAllowed";
 
     /**
      * Private constructor for utility class.

--- a/src/main/java/edu/ucla/library/iiif/auth/TemplateKeys.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/TemplateKeys.java
@@ -22,11 +22,6 @@ public final class TemplateKeys {
     public static final String CLIENT_IP_ADDRESS = "clientIpAddress";
 
     /**
-     * The degraded allowed key.
-     */
-    public static final String DEGRADED_ALLOWED = "degradedAllowed";
-
-    /**
      * The window close delay key.
      */
     public static final String WINDOW_CLOSE_DELAY = "windowCloseDelay";

--- a/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieService.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieService.java
@@ -60,11 +60,10 @@ public interface AccessCookieService {
      *
      * @param aClientIpAddress The IP address of the client
      * @param aIsOnCampusNetwork If the client is on a campus network subnet
-     * @param aIsDegradedAllowed If the origin allows degraded access to content
      * @return A Future that resolves to a value that can be used to create a cookie with
      *         {@link Cookie#cookie(String, String)}
      */
-    Future<String> generateCookie(String aClientIpAddress, boolean aIsOnCampusNetwork, boolean aIsDegradedAllowed);
+    Future<String> generateCookie(String aClientIpAddress, boolean aIsOnCampusNetwork);
 
     /**
      * Decrypts an access cookie value.

--- a/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceImpl.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceImpl.java
@@ -166,11 +166,9 @@ public class AccessCookieServiceImpl implements AccessCookieService {
     }
 
     @Override
-    public Future<String> generateCookie(final String aClientIpAddress, final boolean aIsOnCampusNetwork,
-            final boolean aIsDegradedAllowed) {
+    public Future<String> generateCookie(final String aClientIpAddress, final boolean aIsOnCampusNetwork) {
         final JsonObject cookieData = new JsonObject().put(CookieJsonKeys.CLIENT_IP_ADDRESS, aClientIpAddress)
-                .put(CookieJsonKeys.CAMPUS_NETWORK, aIsOnCampusNetwork)
-                .put(CookieJsonKeys.DEGRADED_ALLOWED, aIsDegradedAllowed);
+                .put(CookieJsonKeys.CAMPUS_NETWORK, aIsOnCampusNetwork);
         final byte[] encryptedCookieData;
         final JsonObject unencodedCookie;
         final String cookie;

--- a/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseService.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/services/DatabaseService.java
@@ -76,21 +76,4 @@ public interface DatabaseService {
      * @return A Future that resolves once the items have been set
      */
     Future<Void> setItems(JsonArray aItems);
-
-    /**
-     * Gets the "degraded allowed" for content hosted at the given origin.
-     *
-     * @param aOrigin The origin
-     * @return A Future that resolves to the degraded allowed once it's been fetched
-     */
-    Future<Boolean> getDegradedAllowed(String aOrigin);
-
-    /**
-     * Sets the given "degraded allowed" for content hosted at the given origin.
-     *
-     * @param aOrigin The origin
-     * @param aDegradedAllowed The degraded allowed to set for the origin
-     * @return A Future that resolves once the degraded allowed has been set
-     */
-    Future<Void> setDegradedAllowed(String aOrigin, boolean aDegradedAllowed);
 }

--- a/src/main/resources/templates/cookie.hbs
+++ b/src/main/resources/templates/cookie.hbs
@@ -11,13 +11,7 @@
         hosted at: <em id="origin">{{origin}}</em>
     <p>
     <p>
-        {{#if degradedAllowed}}
-        Degraded versions of the content are accessible
-        {{else}}
-        The content is not accessible
-        {{/if}}
-
-        to users outside of the Campus Network.
+        Degraded versions of the content are accessible to users outside of the Campus Network.
     </p>
     <p>
         Your current IP address: <em id="client-ip-address">{{clientIpAddress}}</em>

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AbstractHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AbstractHandlerIT.java
@@ -149,8 +149,7 @@ public abstract class AbstractHandlerIT {
             final DatabaseService db = DatabaseService.create(aVertx, config);
             @SuppressWarnings("rawtypes")
             final List<Future> dbOps = List.of(db.setAccessMode(TEST_ID_OPEN_ACCESS, 0),
-                    db.setAccessMode(TEST_ID_TIERED_ACCESS, 1), db.setAccessMode(TEST_ID_ALL_OR_NOTHING_ACCESS, 2),
-                    db.setDegradedAllowed(TEST_ORIGIN, true));
+                    db.setAccessMode(TEST_ID_TIERED_ACCESS, 1), db.setAccessMode(TEST_ID_ALL_OR_NOTHING_ACCESS, 2));
 
             myConfig = config;
             myWebClient = WebClient.create(aVertx);

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/AccessCookieHandlerIT.java
@@ -14,7 +14,6 @@ import io.netty.handler.codec.http.cookie.CookieHeaderNames.SameSite;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 
 import org.jsoup.Jsoup;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -78,28 +77,6 @@ public final class AccessCookieHandlerIT extends AbstractHandlerIT {
 
                 assertEquals(SameSite.None, ((DefaultCookie) cookie).sameSite());
                 assertTrue(cookie.isSecure());
-
-                aContext.completeNow();
-            });
-        }).onFailure(aContext::failNow);
-    }
-
-    /**
-     * Tests that a client can't obtain an access cookie for an unknown origin.
-     *
-     * @param aVertx A Vert.x instance
-     * @param aContext A test context
-     */
-    @Test
-    public void testGetCookieUnknownOrigin(final Vertx aVertx, final VertxTestContext aContext) {
-        final String requestURI = StringUtils.format(GET_COOKIE_PATH,
-                URLEncoder.encode("https://iiif.unknown.library.ucla.edu", StandardCharsets.UTF_8));
-        final HttpRequest<?> getCookie = myWebClient.get(myPort, Constants.INADDR_ANY, requestURI);
-
-        getCookie.send().onSuccess(response -> {
-            aContext.verify(() -> {
-                assertEquals(HTTP.BAD_REQUEST, response.statusCode());
-                assertEquals(MediaType.TEXT_HTML.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
 
                 aContext.completeNow();
             });

--- a/src/test/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceTest.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/AccessCookieServiceTest.java
@@ -140,9 +140,7 @@ public class AccessCookieServiceTest extends AbstractServiceTest {
     public final void testValidateGeneratedCookie(final Vertx aVertx, final VertxTestContext aContext) {
         final String clientIpAddress = LOCALHOST;
         final boolean isCampusNetwork = true;
-        final boolean isDegradedAllowed = false;
-        final Future<String> generateCookie =
-                myServiceProxy.generateCookie(clientIpAddress, isCampusNetwork, isDegradedAllowed);
+        final Future<String> generateCookie = myServiceProxy.generateCookie(clientIpAddress, isCampusNetwork);
 
         generateCookie.compose(cookie -> {
             // The result is base64-encoded JSON with three keys
@@ -157,8 +155,7 @@ public class AccessCookieServiceTest extends AbstractServiceTest {
             return myServiceProxy.decryptCookie(cookie, clientIpAddress);
         }).onSuccess(decryptedCookie -> {
             final JsonObject expected = new JsonObject().put(CookieJsonKeys.CLIENT_IP_ADDRESS, clientIpAddress)
-                    .put(CookieJsonKeys.CAMPUS_NETWORK, isCampusNetwork)
-                    .put(CookieJsonKeys.DEGRADED_ALLOWED, isDegradedAllowed);
+                    .put(CookieJsonKeys.CAMPUS_NETWORK, isCampusNetwork);
 
             completeIfExpectedElseFail(decryptedCookie, expected, aContext);
         }).onFailure(aContext::failNow);
@@ -175,9 +172,7 @@ public class AccessCookieServiceTest extends AbstractServiceTest {
     public final void testInvalidateTamperedCookie(final Vertx aVertx, final VertxTestContext aContext) {
         final String clientIpAddress = LOCALHOST;
         final boolean isCampusNetwork = false;
-        final boolean isDegradedAllowed = false;
-        final Future<String> generateCookie =
-                myServiceProxy.generateCookie(clientIpAddress, isCampusNetwork, isDegradedAllowed);
+        final Future<String> generateCookie = myServiceProxy.generateCookie(clientIpAddress, isCampusNetwork);
 
         generateCookie.compose(cookie -> {
             final JsonObject decodedCookie = new JsonObject(new String(Base64.getDecoder().decode(cookie.getBytes())));
@@ -203,9 +198,7 @@ public class AccessCookieServiceTest extends AbstractServiceTest {
             if (decryptedCookie.containsKey(CookieJsonKeys.CLIENT_IP_ADDRESS) &&
                     decryptedCookie.getString(CookieJsonKeys.CLIENT_IP_ADDRESS).equals(clientIpAddress) &&
                     decryptedCookie.containsKey(CookieJsonKeys.CAMPUS_NETWORK) &&
-                    decryptedCookie.getBoolean(CookieJsonKeys.CAMPUS_NETWORK) == isCampusNetwork &&
-                    decryptedCookie.containsKey(CookieJsonKeys.DEGRADED_ALLOWED) &&
-                    decryptedCookie.getBoolean(CookieJsonKeys.DEGRADED_ALLOWED) == isDegradedAllowed) {
+                    decryptedCookie.getBoolean(CookieJsonKeys.CAMPUS_NETWORK) == isCampusNetwork) {
                 aContext.failNow(StringUtils.format(MessageCodes.AUTH_009, decryptedCookie));
             } else {
                 aContext.completeNow();

--- a/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/services/DatabaseServiceIT.java
@@ -194,64 +194,6 @@ public class DatabaseServiceIT extends AbstractServiceTest {
         });
     }
 
-    /**
-     * Tests reading an origin whose "degraded allowed" has not been set.
-     *
-     * @param aContext A test context
-     */
-    @Test
-    final void testGetDegradedAllowedUnset(final VertxTestContext aContext) {
-        final String url = "https://library.ucla.edu";
-        final String expected = NULL;
-
-        myServiceProxy.getDegradedAllowed(url).onFailure(details -> {
-            final ServiceException error = (ServiceException) details;
-
-            aContext.verify(() -> {
-                assertEquals(Error.NOT_FOUND.ordinal(), error.failureCode());
-                assertEquals(url, error.getMessage());
-
-                aContext.completeNow();
-            });
-        }).onSuccess(result -> {
-            // The following will always fail
-            completeIfExpectedElseFail(result, expected, aContext);
-        });
-    }
-
-    /**
-     * Tests reading an origin whose "degraded allowed" has been set once.
-     *
-     * @param aContext A test context
-     */
-    @Test
-    final void testGetDegradedAllowedSetOnce(final VertxTestContext aContext) {
-        final String url = "https://iiif.library.ucla.edu";
-        final boolean expected = true;
-        final Future<Void> setOnce = myServiceProxy.setDegradedAllowed(url, expected);
-
-        setOnce.compose(put -> myServiceProxy.getDegradedAllowed(url)).onSuccess(result -> {
-            completeIfExpectedElseFail(result, expected, aContext);
-        }).onFailure(aContext::failNow);
-    }
-
-    /**
-     * Tests reading an origin whose "degraded allowed" has been set more than once.
-     *
-     * @param aContext A test context
-     */
-    @Test
-    final void testGetDegradedAllowedSetTwice(final VertxTestContext aContext) {
-        final String url = "https://iiif.sinaimanuscripts.library.ucla.edu";
-        final boolean expected = true;
-        final Future<Void> setTwice = myServiceProxy.setDegradedAllowed(url, false)
-                .compose(put -> myServiceProxy.setDegradedAllowed(url, expected));
-
-        setTwice.compose(put -> myServiceProxy.getDegradedAllowed(url)).onSuccess(result -> {
-            completeIfExpectedElseFail(result, expected, aContext);
-        }).onFailure(aContext::failNow);
-    }
-
     protected Logger getLogger() {
         return LOGGER;
     }

--- a/src/test/resources/db/authzdb.sql
+++ b/src/test/resources/db/authzdb.sql
@@ -41,14 +41,7 @@ CREATE TABLE public.items (
     access_mode smallint DEFAULT 0 NOT NULL
 );
 
-CREATE TABLE public.origins (
-    url text NOT NULL,
-    degraded_allowed boolean DEFAULT FALSE NOT NULL
-);
-
 ALTER TABLE public.items OWNER TO postgres;
-
-ALTER TABLE public.origins OWNER TO postgres;
 
 --
 -- Name: COLUMN items.uid; Type: COMMENT; Schema: public; Owner: postgres
@@ -63,30 +56,10 @@ COMMENT ON COLUMN public.items.uid IS 'The unique identifier of the requested ob
 COMMENT ON COLUMN public.items.access_mode IS 'The access mode of the requested item: 0 is open, 1 is restricted to campus network users';
 
 --
--- Name: COLUMN origins.url; Type: COMMENT; Schema: public; Owner: postgres
---
-
-COMMENT ON COLUMN public.origins.url IS 'The URL origin of an access request';
-
---
--- Name: COLUMN origins.degraded_allowed; Type: COMMENT; Schema: public; Owner: postgres
---
-
-COMMENT ON COLUMN public.origins.degraded_allowed IS 'Whether this origin allows degraded access';
-
-
---
 -- Name: items; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
 COPY public.items (uid, access_mode) FROM stdin;
-\.
-
---
--- Name: origins; Type: TABLE DATA; Schema: public; Owner: postgres
---
-
-COPY public.origins (url, degraded_allowed) FROM stdin;
 \.
 
 --
@@ -97,22 +70,8 @@ ALTER TABLE ONLY public.items
     ADD CONSTRAINT items_pkey PRIMARY KEY (uid);
 
 --
--- Name: origins_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.origins
-    ADD CONSTRAINT origins_pkey PRIMARY KEY (url);
-
---
 -- Name: TABLE items; Type: ACL; Schema: public; Owner: postgres
 --
 
 GRANT SELECT ON TABLE public.items TO authz_reader;
 GRANT ALL ON TABLE public.items TO authz_writer;
-
---
--- Name: TABLE origins; Type: ACL; Schema: public; Owner: postgres
---
-
-GRANT SELECT ON TABLE public.origins TO authz_reader;
-GRANT ALL ON TABLE public.origins TO authz_writer;


### PR DESCRIPTION
The `origins` table is a vestige of misunderstanding IIIF Auth 1.0; since the info.json is the carrier of auth info, access mode is determined on a per-item basis by the `access_mode` field in the `items` table.