### PR TITLE
[SERV-460] Determine item access mode from visibility field in CSV

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -553,6 +553,30 @@
                 <skip>${skip.hauth.container}</skip>
               </run>
             </hauth>
+            <hauth_import_items>
+              <name>import-items</name>
+              <build>
+                <args>
+                  <CSV_VOLUME_MOUNT_POINT>/csv</CSV_VOLUME_MOUNT_POINT>
+                </args>
+                <dockerFile>${project.basedir}/src/main/scripts/import-items/Dockerfile</dockerFile>
+              </build>
+              <run>
+                <containerNamePattern>hauth_import_items</containerNamePattern>
+                <volumes>
+                  <bind>
+                    <volume>${project.basedir}/src/test/resources/csv:/csv</volume>
+                  </bind>
+                </volumes>
+                <env>
+                  <HAUTH_API_KEY>${test.api.key}</HAUTH_API_KEY>
+                  <HAUTH_BASE_URL>http://172.17.0.1:${test.http.port}</HAUTH_BASE_URL>
+                </env>
+                <dependsOn>
+                  <container>hauth</container>
+                </dependsOn>
+              </run>
+            </hauth_import_items>
           </imagesMap>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -575,7 +575,7 @@
                 <cmd>
                   <arg>${test.api.key}</arg>
                   <arg>http://172.17.0.1:${test.http.port}</arg>
-                  <arg>/csv/**/*.csv</arg>
+                  <arg>/csv</arg>
                 </cmd>
                 <dependsOn>
                   <container>hauth</container>

--- a/pom.xml
+++ b/pom.xml
@@ -562,9 +562,6 @@
             <hauth_import_items>
               <name>import-items</name>
               <build>
-                <args>
-                  <CSV_VOLUME_MOUNT_POINT>/csv</CSV_VOLUME_MOUNT_POINT>
-                </args>
                 <dockerFile>${project.basedir}/src/main/scripts/import-items/Dockerfile</dockerFile>
               </build>
               <run>
@@ -574,13 +571,18 @@
                     <volume>${project.basedir}/src/test/resources/csv:/csv</volume>
                   </bind>
                 </volumes>
-                <env>
-                  <HAUTH_API_KEY>${test.api.key}</HAUTH_API_KEY>
-                  <HAUTH_BASE_URL>http://172.17.0.1:${test.http.port}</HAUTH_BASE_URL>
-                </env>
+                <cmd>
+                  <arg>${test.api.key}</arg>
+                  <arg>http://172.17.0.1:${test.http.port}</arg>
+                  <arg>/csv/**/*.csv</arg>
+                </cmd>
                 <dependsOn>
                   <container>hauth</container>
                 </dependsOn>
+                <wait>
+                  <exit>0</exit>
+                  <time>30000</time>
+                </wait>
               </run>
             </hauth_import_items>
           </imagesMap>

--- a/pom.xml
+++ b/pom.xml
@@ -579,10 +579,6 @@
                 <dependsOn>
                   <container>hauth</container>
                 </dependsOn>
-                <wait>
-                  <exit>0</exit>
-                  <time>30000</time>
-                </wait>
               </run>
             </hauth_import_items>
           </imagesMap>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <freelib.utils.version>3.3.0</freelib.utils.version>
     <cidr.ip.version>1.0.1</cidr.ip.version>
     <commons.codec.version>1.15</commons.codec.version>
-    <vertx.version>4.4.2</vertx.version>
+    <vertx.version>4.4.4</vertx.version>
 
     <!-- Build plugin versions -->
     <clean.plugin.version>3.1.0</clean.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <cantaloupe.version>5.0.4-1</cantaloupe.version>
     <auth.delegate.version>0.0.1-SNAPSHOT</auth.delegate.version>
     <jsoup.version>1.14.3</jsoup.version>
+    <csveed.version>0.7.3</csveed.version>
 
     <!-- Fluency logback dependencies -->
     <fluency.core.version>2.6.4</fluency.core.version>
@@ -231,7 +232,7 @@
     <dependency>
       <groupId>org.csveed</groupId>
       <artifactId>csveed</artifactId>
-      <version>0.7.3</version>
+      <version>${csveed.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,12 @@
       <version>${jsoup.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.csveed</groupId>
+      <artifactId>csveed</artifactId>
+      <version>0.7.3</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Fluency logback dependencies -->
     <dependency>

--- a/src/main/resources/hauth_messages.xml
+++ b/src/main/resources/hauth_messages.xml
@@ -27,5 +27,7 @@
   <entry key="AUTH_019">Expected validation of expired cookie to fail, but it succeeded</entry>
   <entry key="AUTH_020">Generated cookies: {}={}, {}={} (cleartext: "{}")</entry>
   <entry key="AUTH_021">Request headers: {}</entry>
+  <entry key="AUTH_022">Expected access mode to be {} for item {} with visibility "{}", but was {}</entry>
+  <entry key="AUTH_023">Unknown visibility value "{}"</entry>
 
 </properties>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -19,6 +19,9 @@
     </then>
     </if>
   </logger>
+  <logger name="org.csveed" level="WARN" additivity="false">
+    <appender-ref ref="STDOUT" />
+  </logger>
 
   <!-- Loggers for our application -->
   <logger name="edu.ucla.library.iiif.fester" level="${logLevel}" additivity="true">

--- a/src/main/scripts/import-items/Dockerfile
+++ b/src/main/scripts/import-items/Dockerfile
@@ -1,16 +1,11 @@
 FROM python:3
 
-# Copy over the executable
+# Install the executable
 
 WORKDIR /usr/local/bin
-COPY docker-entrypoint.sh .
-COPY import-items.py .
-RUN chmod +x docker-entrypoint.sh import-items.py
-
-# Install script dependencies
-
-COPY requirements.txt .
+COPY docker-entrypoint.sh import-items.py requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
+RUN chmod +x docker-entrypoint.sh import-items.py
 
 SHELL [ "/bin/bash", "-c" ]
 ENTRYPOINT [ "/usr/local/bin/docker-entrypoint.sh" ]

--- a/src/main/scripts/import-items/Dockerfile
+++ b/src/main/scripts/import-items/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3
+
+# Install app
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY *.py .
+
+# Run app
+
+SHELL [ "/bin/bash", "-c" ]
+RUN shopt -s globstar
+
+ARG CSV_VOLUME_MOUNT_POINT
+WORKDIR $CSV_VOLUME_MOUNT_POINT
+
+CMD python /usr/src/app/import-items.py --api-key $HAUTH_API_KEY $HAUTH_BASE_URL {.,**}/*.csv

--- a/src/main/scripts/import-items/Dockerfile
+++ b/src/main/scripts/import-items/Dockerfile
@@ -1,20 +1,16 @@
 FROM python:3
 
-# Install app
+# Copy over the executable
 
-WORKDIR /usr/src/app
+WORKDIR /usr/local/bin
+COPY docker-entrypoint.sh .
+COPY import-items.py .
+RUN chmod +x docker-entrypoint.sh import-items.py
 
-COPY requirements.txt ./
+# Install script dependencies
+
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY *.py .
-
-# Run app
-
 SHELL [ "/bin/bash", "-c" ]
-RUN shopt -s globstar
-
-ARG CSV_VOLUME_MOUNT_POINT
-WORKDIR $CSV_VOLUME_MOUNT_POINT
-
-CMD python /usr/src/app/import-items.py --api-key $HAUTH_API_KEY $HAUTH_BASE_URL {.,**}/*.csv
+ENTRYPOINT [ "/usr/local/bin/docker-entrypoint.sh" ]

--- a/src/main/scripts/import-items/docker-entrypoint.sh
+++ b/src/main/scripts/import-items/docker-entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# Handle arguments that use globstar
 shopt -s globstar
 
-import-items.py --api-key "${1}" "${2}" "${3}"
+import-items.py --api-key "${1}" "${2}" "${3}"/**/*.csv

--- a/src/main/scripts/import-items/docker-entrypoint.sh
+++ b/src/main/scripts/import-items/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Handle arguments that use globstar
+shopt -s globstar
+
+import-items.py --api-key ${1} ${2} ${3}

--- a/src/main/scripts/import-items/docker-entrypoint.sh
+++ b/src/main/scripts/import-items/docker-entrypoint.sh
@@ -3,4 +3,4 @@
 # Handle arguments that use globstar
 shopt -s globstar
 
-import-items.py --api-key ${1} ${2} ${3}
+import-items.py --api-key "${1}" "${2}" "${3}"

--- a/src/main/scripts/import-items/import-items.py
+++ b/src/main/scripts/import-items/import-items.py
@@ -9,6 +9,13 @@ from os.path import basename
 from requests import post
 from typing import List, Dict
 
+def docstring_parameter(*sub):
+    """Allows for formatting a method docstring with parameters. C.f. https://stackoverflow.com/a/10308363"""
+    def dec(obj):
+        obj.__doc__ = obj.__doc__.format(*sub)
+        return obj
+    return dec
+
 class AccessMode(Enum):
 
     """The access mode choices."""
@@ -16,17 +23,43 @@ class AccessMode(Enum):
     TIERED = 1
     ALL_OR_NOTHING = 2
 
+"""The mapping from visibility to access mode."""
+visibility_map = {
+    'open': AccessMode.OPEN,
+    'ucla': AccessMode.TIERED,
+    'private': AccessMode.TIERED, # will eventually mean UCLA all-or-nothing access; treat as tiered for now
+    'sinai': AccessMode.ALL_OR_NOTHING
+}
+
+def visibility_map_as_table() -> str:
+    """Renders a nice textual representation of the mapping from visibility to access mode."""
+    table = 'Visibility\tAccess mode\n'
+    table += '----------\t-----------\n'
+
+    for visibility, access_mode in visibility_map.items():
+        table += visibility + '\t\t' + str(access_mode.name) + '\n'
+
+    return table
+
 @click.command()
-@click.option('--access-mode', '-m', help='The access mode to use for all items in each INPUT_CSV.', required=False,
+@click.option('--access-mode', '-m', help='The access mode to use for all items in each INPUT_CSV (instead of the Visibility field value).', required=False,
               type=click.Choice([name for name, member in AccessMode.__members__.items()], case_sensitive=False))
 @click.option('--api-key', '-k', help='The API key for accessing the admin API.', required=True)
 @click.argument('hauth-base-url', nargs=1)
 @click.argument('input-csv', required=True, nargs=-1, type=click.File('r'))
+@docstring_parameter(visibility_map_as_table())
 def import_items(access_mode, api_key, hauth_base_url, input_csv):
-    """Import items into Hauth.
+    """
+Import items into Hauth.
 
-    Instructs the Hauth instance at HAUTH_BASE_URL to use the specified access mode for all items in each INPUT_CSV.
-    Exits with zero status only if all items are imported successfully.
+Instructs the Hauth instance at HAUTH_BASE_URL to register the access modes of all items in each INPUT_CSV.
+
+Unless --access-mode is supplied, the access mode of each item is determined from the Visibility field of its corresponding INPUT_CSV as follows:
+
+\b
+{0}
+
+Exits with zero status only if all items are imported successfully.
     """
     request_url = hauth_base_url + '/items'
     request_headers = {'Content-Type': 'application/json', 'X-API-KEY': api_key}
@@ -68,15 +101,8 @@ def get_access_mode(row: Dict) -> AccessMode:
     field_name = 'Visibility'
     field_value = row[field_name]
 
-    if field_value == 'open':
-        return AccessMode.OPEN
-    elif field_value == 'ucla':
-        return AccessMode.TIERED
-    elif field_value == 'private':
-        # UCLA all-or-nothing access, which is not yet implemented; treat as UCLA tiered access for now
-        return AccessMode.TIERED
-    elif field_value == 'sinai':
-        return AccessMode.ALL_OR_NOTHING
+    if field_value in visibility_map:
+        return visibility_map[field_value]
     else:
         raise ValueError('Unknown {} "{}" for row "{}"'.format(field_name, field_value, row))
 

--- a/src/main/scripts/import-items/import-items.py
+++ b/src/main/scripts/import-items/import-items.py
@@ -63,7 +63,7 @@ def request_payload(file: TextIOBase, access_mode_override: AccessMode) -> List[
         for row in DictReader(file)
     ]
 
-def get_access_mode(row: List) -> AccessMode:
+def get_access_mode(row: Dict) -> AccessMode:
     """Determines the access mode of an item."""
     field_name = 'Visibility'
     field_value = row[field_name]

--- a/src/main/scripts/import-items/import-items.py
+++ b/src/main/scripts/import-items/import-items.py
@@ -23,7 +23,7 @@ class AccessMode(Enum):
     TIERED = 1
     ALL_OR_NOTHING = 2
 
-"""The mapping from visibility to access mode."""
+# The mapping from visibility to access mode.
 visibility_map = {
     'open': AccessMode.OPEN,
     'ucla': AccessMode.TIERED,

--- a/src/test/java/edu/ucla/library/iiif/auth/handlers/ItemsHandlerIT.java
+++ b/src/test/java/edu/ucla/library/iiif/auth/handlers/ItemsHandlerIT.java
@@ -3,9 +3,14 @@ package edu.ucla.library.iiif.auth.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.Reader;
+import java.io.StringReader;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
+import org.csveed.api.CsvClient;
+import org.csveed.api.CsvClientImpl;
+import org.csveed.api.Row;
 import org.junit.jupiter.api.Test;
 
 import info.freelibrary.util.Constants;
@@ -214,5 +219,24 @@ public final class ItemsHandlerIT extends AbstractHandlerIT {
                 aContext.completeNow();
             });
         }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * FIXME Note that the container already hit the API for us with all the CSVs in src/test/resources/csv; here we
+     * just test to see that it worked as intended.
+     *
+     * @param aVertx
+     * @param aContext
+     */
+    @Test
+    public void testImportItemsScript(final Vertx aVertx, final VertxTestContext aContext) {
+        // FIXME: read all the CSVs
+        final Reader reader =
+                new StringReader(aVertx.fileSystem().readFileBlocking("src/test/resources/csv/allied.csv").toString());
+        final CsvClient<Row> client = new CsvClientImpl<>(reader);
+
+        for (final Row row : client.readRows()) {
+            // FIXME
+        }
     }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -30,6 +30,9 @@
   <logger name="io.swagger.v3.parser" level="WARN" additivity="false">
     <appender-ref ref="STDOUT" />
   </logger>
+  <logger name="org.csveed" level="WARN" additivity="false">
+    <appender-ref ref="STDOUT" />
+  </logger>
 
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
The `--access-mode` flag is now an optional override.

Here's the new help output:

```bash
$ ./import-items.py --help
Usage: import-items.py [OPTIONS] HAUTH_BASE_URL INPUT_CSV...

  Import items into Hauth.

  Instructs the Hauth instance at HAUTH_BASE_URL to register the access modes
  of all items in each INPUT_CSV.

  Unless --access-mode is supplied, the access mode of each item is determined
  from the Visibility field of its corresponding INPUT_CSV as follows:

  Visibility      Access mode
  ----------      -----------
  open            OPEN
  ucla            TIERED
  private         TIERED
  sinai           ALL_OR_NOTHING

  Exits with zero status only if all items are imported successfully.

Options:
  -m, --access-mode [OPEN|TIERED|ALL_OR_NOTHING]
                                  The access mode to use for all items in each
                                  INPUT_CSV (instead of the Visibility field
                                  value).
  -k, --api-key TEXT              The API key for accessing the admin API.
                                  [required]
  --help                          Show this message and exit.

```