### PR TITLE
[SERV-908] Reduce cleverness of import-items setup instructions

### DIFF
--- a/src/main/scripts/import-items/README.md
+++ b/src/main/scripts/import-items/README.md
@@ -17,6 +17,9 @@ python3 -m venv venv_import_items
 
 # Install the script dependencies to the virtual environment
 pip install -r requirements.txt
+
+# Ensure the script is executable
+chmod +x import-items.py
 ```
 
 Also, you may want to add something like this to your shell's initialization file (e.g. `~/.zshrc`), so that you can easily reference the script from anywhere:

--- a/src/main/scripts/import-items/README.md
+++ b/src/main/scripts/import-items/README.md
@@ -9,8 +9,13 @@ Tested with Python 3.6.9.
 ```bash
 #!/bin/bash
 
-python3 -m venv venv_import_items && . $_/bin/activate
-# (exit virtual environment later with `deactivate`)
+# Create a virtual environment to isolate the system Python installation from the script dependencies that we'll download
+python3 -m venv venv_import_items
+
+# Activate the virtual environment; deactivate it later by running `deactivate`
+. venv_import_items/bin/activate
+
+# Install the script dependencies to the virtual environment
 pip install -r requirements.txt
 ```
 

--- a/src/main/scripts/import-items/README.md
+++ b/src/main/scripts/import-items/README.md
@@ -19,6 +19,12 @@ python3 -m venv venv_import_items
 pip install -r requirements.txt
 ```
 
+Also, you may want to add something like this to your shell's initialization file (e.g. `~/.zshrc`), so that you can easily reference the script from anywhere:
+
+```bash
+PATH=$PATH:$HOME/path/to/UCLALibrary/hauth/src/main/scripts/import-items
+```
+
 ## Example usage
 
 Assuming that all CSV files in the current working directory contain open access items, and a Hauth instance is running at http://example.com:


### PR DESCRIPTION
It was probably not wise in the first place to wrap the activation command up with the creation command. The instructions should now be easier to follow and use.