### PR TITLE
Don't log request headers in AccessModeHandler

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/auth/handlers/AccessModeHandler.java
@@ -52,8 +52,6 @@ public class AccessModeHandler implements Handler<RoutingContext> {
         final HttpServerResponse response = aContext.response() //
                 .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString());
 
-        LOGGER.debug(MessageCodes.AUTH_021, request.headers().entries());
-
         myDatabaseServiceProxy.getAccessMode(id).onSuccess(accessMode -> {
             final JsonObject responseData = new JsonObject() //
                     .put(ResponseJsonKeys.ACCESS_MODE, AccessMode.values()[accessMode]);


### PR DESCRIPTION
In solving SERV-917 and SERV-918, we found this log message to be extra
noise, mostly, and think it's best to remove it.
