### PR TITLE
[SERV-994] Fix release build with workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           maven_args: >
             -Drevision=${{ github.event.release.tag_name }}
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -Ddocker.showLogs=true
-            -DskipNexusStagingDeployMojo=true -DautoReleaseAfterClose=false -Dgpg.skip=true
+            -DskipNexusStagingDeployMojo=true -DautoReleaseAfterClose=false -Dgpg.skip=true -DskipTests
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -624,6 +624,7 @@
               <goal>push</goal>
             </goals>
             <configuration>
+              <filter>hauth</filter>
               <images>
                 <image>
                   <!-- Registry account, if supplied, must end in a slash (e.g. "account/") -->
@@ -726,17 +727,6 @@
                   </args>
                 </configuration>
               </execution>
-              <execution>
-                <id>snyk-monitor</id>
-                <goals>
-                  <goal>monitor</goal>
-                </goals>
-                <configuration>
-                  <args>
-                    <arg>--org=${env.UCLALIBRARY_SNYK_ORG}</arg>
-                  </args>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>
@@ -768,44 +758,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- A profile to use to do a native compile using GraalVM's native-image -->
-    <profile>
-      <id>native-compile</id>
-      <build>
-        <plugins>
-          <!-- This packages the code so the native-image plugin can access it -->
-          <plugin>
-            <artifactId>maven-jar-plugin</artifactId>
-            <version>${jar.plugin.version}</version>
-          </plugin>
-          <!-- This creates a native binary from the packaged jar and its dependencies -->
-          <plugin>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>native-image-maven-plugin</artifactId>
-            <version>${graalvm.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>native-image</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <imageName>${project.artifactId}</imageName>
-              <mainClass>io.vertx.core.Launcher</mainClass>
-              <buildArgs>
-                <buildArg>--static</buildArg>
-                <buildArg>--libc=musl</buildArg>
-                <buildArg>-H:+ReportExceptionStackTraces</buildArg>
-                <buildArg>-H:+PrintClassInitialization</buildArg>
-                <buildArg>-H:TraceClassInitialization=com.sun.org.apache.xerces.internal.impl.XMLEntityScanner,io.netty.channel.socket.InternetProtocolFamily</buildArg>
-              </buildArgs>
-            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Releases currently don't work because of the way the POM sets up the test containers. Using a maven-docker-plugin `build` configuration to build containers just used for testing is problematic because it means those containers will attempt to be pushed up to DockerHub along with the official release container. This breaks the release build, the only place where this configuration comes into play (even though the versioned Hauth container makes it up to DockerHub successfully).

A real fix would be to rewrite the way the POM sets up the test containers but for a quick and dirty workaround we'll turn off testing for release builds and set a maven-docker-plugin filter on the `deploy` configuration so that only the `hauth` container is built. This should be okay because of the way we've set up our branches (requiring a PR branch, where tests are run, before anything is merged into `main`). With this config, official releases should only be done through GitHub Actions where we have this control in place.

Two unrelated changes also in this PR:
* Turn off snyk `monitor` config -- the `test` config is sufficient
* Remove the GraalVM config -- we'll never compile this project that way